### PR TITLE
Expand inventory through kube_juliett cluster group

### DIFF
--- a/inventories/hosts.ini
+++ b/inventories/hosts.ini
@@ -11,3 +11,59 @@ kube07 controlplane=true
 kube08 controlplane=true
 kube09
 kube10
+
+[kube_charlie]
+kube11 controlplane=true
+kube12 controlplane=true
+kube13 controlplane=true
+kube14
+kube15
+
+[kube_delta]
+kube16 controlplane=true
+kube17 controlplane=true
+kube18 controlplane=true
+kube19
+kube20
+
+[kube_echo]
+kube21 controlplane=true
+kube22 controlplane=true
+kube23 controlplane=true
+kube24
+kube25
+
+[kube_foxtrot]
+kube26 controlplane=true
+kube27 controlplane=true
+kube28 controlplane=true
+kube29
+kube30
+
+[kube_golf]
+kube31 controlplane=true
+kube32 controlplane=true
+kube33 controlplane=true
+kube34
+kube35
+
+[kube_hotel]
+kube36 controlplane=true
+kube37 controlplane=true
+kube38 controlplane=true
+kube39
+kube40
+
+[kube_india]
+kube41 controlplane=true
+kube42 controlplane=true
+kube43 controlplane=true
+kube44
+kube45
+
+[kube_juliett]
+kube46 controlplane=true
+kube47 controlplane=true
+kube48 controlplane=true
+kube49
+kube50


### PR DESCRIPTION
## Summary
- add kube_charlie through kube_juliett host groups to the inventory
- mark the first three nodes in each group as control plane members to match the existing pattern

## Testing
- not run (inventory-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8382119488323ad1ce2628d53d3ed