### PR TITLE
Add Puppet agent run to maintenance playbook

### DIFF
--- a/playbooks/maintenance.yml
+++ b/playbooks/maintenance.yml
@@ -16,6 +16,16 @@
               - --ignore-daemonsets
               - --delete-empty-data
 
+        - name: Run Puppet agent
+          ansible.builtin.command:
+            argv:
+              - puppet
+              - agent
+              - --test
+          register: puppet_agent_result
+          changed_when: puppet_agent_result.rc == 2
+          failed_when: puppet_agent_result.rc not in [0, 2]
+
         - name: Apply system updates
           ansible.builtin.dnf:
             name: "*"
@@ -52,6 +62,16 @@
               - "{{ inventory_hostname }}"
               - --ignore-daemonsets
               - --delete-empty-data
+
+        - name: Run Puppet agent
+          ansible.builtin.command:
+            argv:
+              - puppet
+              - agent
+              - --test
+          register: puppet_agent_result
+          changed_when: puppet_agent_result.rc == 2
+          failed_when: puppet_agent_result.rc not in [0, 2]
 
         - name: Apply system updates
           ansible.builtin.dnf:


### PR DESCRIPTION
## Summary
- run `puppet agent --test` before applying updates on both control plane and worker maintenance blocks
- treat Puppet exit code 2 as a successful run that changed resources while failing on any other return code

## Testing
- `ansible-lint playbooks/maintenance.yml` *(fails: command not found)*
- `ansible-playbook --syntax-check playbooks/maintenance.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d839def79c8323adad556a6eaa6b36