### PR TITLE
Add helper script for installing Ansible tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 Welcome to the repository! This document sets expectations for contributors working anywhere in this project tree. Please read it before submitting changes.
 
 ## Testing
+- Before running any linting or syntax-check commands, execute `./scripts/setup-ansible.sh` to install Ansible and the required tooling. Activate the virtual environment it creates so that the commands are available in your shell.
 - Run `ansible-lint` against any roles, playbooks, or modules you modify. Address all reported issues before opening a pull request.
 - Validate playbooks with `ansible-playbook --syntax-check` for each playbook touched in your change. Syntax checks must pass without warnings or errors.
 - Include the commands you executed (and their results) in your pull request description so reviewers can verify the checks.

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ This repository provides Ansible resources for operating Rancher Kubernetes Engi
 
 ## Local development setup
 
-Set up a local Python virtual environment and install Ansible along with the linting tools used by the repository:
+Set up a local Python virtual environment and install Ansible along with the linting tools used by the repository by running the helper script:
 
 ```bash
-python3 -m venv .venv
+./scripts/setup-ansible.sh
 source .venv/bin/activate
-pip install --upgrade pip
-pip install ansible ansible-lint
 ```
+
+> The script creates a `.venv` directory in the repository by default. You can change the location by setting the `VENV_DIR` environment variable before running it.
 
 Confirm the installation succeeded:
 

--- a/scripts/setup-ansible.sh
+++ b/scripts/setup-ansible.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repo root relative to this script
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+VENV_DIR="${VENV_DIR:-${REPO_ROOT}/.venv}"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required but was not found in PATH." >&2
+  exit 1
+fi
+
+python3 -m venv "${VENV_DIR}"
+# shellcheck disable=SC1091
+source "${VENV_DIR}/bin/activate"
+
+pip install --upgrade pip
+pip install --upgrade ansible ansible-lint
+
+echo "Virtual environment created at ${VENV_DIR}" >&2
+echo "Activate it with: source ${VENV_DIR}/bin/activate" >&2
+echo "Ansible tooling installation complete." >&2


### PR DESCRIPTION
## Summary
- add a setup script that provisions a Python virtual environment with ansible and ansible-lint
- document the helper script in the contributor guidance and README so the tooling is installed before running checks

## Testing
- not run (tooling setup change)


------
https://chatgpt.com/codex/tasks/task_e_68d83b8ba1188323a319552d4bc38b4d