### PR TITLE
Ensure maintenance play stops on failure

### DIFF
--- a/playbooks/maintenance.yml
+++ b/playbooks/maintenance.yml
@@ -3,10 +3,11 @@
   hosts: all
   become: true
   serial: 1
+  any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
   tasks:
     - name: Maintenance tasks for control plane nodes
       when: controlplane | default(false) | bool
-      block:
+      block:  # The block runs sequentially; a failure in any step prevents the subsequent steps from executing
         - name: Drain node from cluster scheduling
           ansible.builtin.command:
             argv:
@@ -50,10 +51,11 @@
   hosts: all
   become: true
   serial: 1
+  any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
   tasks:
     - name: Maintenance tasks for worker nodes
       when: not (controlplane | default(false) | bool)
-      block:
+      block:  # The block runs sequentially; a failure in any step prevents the subsequent steps from executing
         - name: Drain node from cluster scheduling
           ansible.builtin.command:
             argv:


### PR DESCRIPTION
## Summary
- ensure the maintenance play halts on the first failure so operators can investigate issues immediately
- document the sequential execution behavior of the maintenance blocks for clarity

## Testing
- ./scripts/setup-ansible.sh
- source .venv/bin/activate
- ansible-lint playbooks/maintenance.yml *(fails: existing no-changed-when and package-latest findings in kubectl/updates tasks)*
- ansible-playbook --syntax-check playbooks/maintenance.yml


------
https://chatgpt.com/codex/tasks/task_e_68d846bb589483238df6d4d5e6d15cd9