### PR TITLE
Refactor RKE2 maintenance tasks to share service facts

### DIFF
--- a/playbooks/tasks/common/rke2_restart.yml
+++ b/playbooks/tasks/common/rke2_restart.yml
@@ -1,0 +1,7 @@
+---
+- ansible.builtin.import_tasks: rke2_service_facts.yml
+
+- name: Restart RKE2 service
+  ansible.builtin.service:
+    name: "{{ rke2_service_name }}"
+    state: restarted

--- a/playbooks/tasks/common/rke2_service_facts.yml
+++ b/playbooks/tasks/common/rke2_service_facts.yml
@@ -1,0 +1,20 @@
+---
+- name: Gather systemd service facts
+  ansible.builtin.service_facts:
+
+- name: Determine RKE2 service name
+  ansible.builtin.set_fact:
+    rke2_service_name: >-
+      {{
+        'rke2-server'
+        if 'rke2-server.service' in ansible_facts.services
+        else 'rke2-agent'
+        if 'rke2-agent.service' in ansible_facts.services
+        else ''
+      }}
+
+- name: Ensure an RKE2 service is present
+  ansible.builtin.assert:
+    that:
+      - rke2_service_name != ''
+    fail_msg: Neither rke2-server nor rke2-agent systemd service was found on this node.

--- a/playbooks/tasks/common/rke2_start.yml
+++ b/playbooks/tasks/common/rke2_start.yml
@@ -1,0 +1,7 @@
+---
+- ansible.builtin.import_tasks: rke2_service_facts.yml
+
+- name: Start RKE2 service
+  ansible.builtin.service:
+    name: "{{ rke2_service_name }}"
+    state: started

--- a/playbooks/tasks/common/rke2_stop.yml
+++ b/playbooks/tasks/common/rke2_stop.yml
@@ -1,0 +1,7 @@
+---
+- ansible.builtin.import_tasks: rke2_service_facts.yml
+
+- name: Stop RKE2 service
+  ansible.builtin.service:
+    name: "{{ rke2_service_name }}"
+    state: stopped


### PR DESCRIPTION
## Summary
- add a shared rke2_service_facts task file that gathers systemd data and validates an RKE2 service is present
- refactor the start, stop, and restart maintenance tasks to import the shared facts helper before managing the service

## Testing
- ./scripts/setup-ansible.sh
- source .venv/bin/activate
- ansible-lint playbooks/maintenance.yml
- ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --syntax-check

------
https://chatgpt.com/codex/tasks/task_e_68d8f0b9e4f48323a97606e988752a62