### PR TITLE
Delegate worker kubectl actions to control-plane nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ See [`docs/README.md`](docs/README.md) for deep dives into the playbook internal
 
 - Ansible 2.12+ (tested syntax)
 - Access to the target nodes with privilege escalation (`become`)
-- `kubectl` available on the nodes being maintained
+- `kubectl` available on control-plane nodes (worker nodes delegate Kubernetes operations to a
+  control-plane host)
 
 ## Local development setup
 

--- a/docs/MAINTENANCE_PLAYBOOK.md
+++ b/docs/MAINTENANCE_PLAYBOOK.md
@@ -31,6 +31,11 @@ executes the following steps:
 
 Each command task has explicit `failed_when` rules so that unexpected return codes surface immediately.
 
+> **Delegation note:** RKE2 worker nodes do not ship with `kubectl` or a KUBECONFIG. The playbook therefore
+> delegates every Kubernetes command to a control-plane host within the same cluster whenever the current
+> target lacks the tooling. This keeps the maintenance workflow functional across all node types while
+> preserving the node-specific scheduling logic.
+
 ## Extending the workflow
 
 - Add new tasks to `maintenance_sequence.yml` to keep the control-plane/worker orchestration intact.

--- a/playbooks/maintenance.yml
+++ b/playbooks/maintenance.yml
@@ -63,6 +63,40 @@
     - name: Maintenance workflow for worker nodes
       when: not (controlplane | default(false) | bool)
       block:
+        - name: Prepare kubectl delegation context for worker nodes
+          block:
+            - name: Discover cluster groups for {{ inventory_hostname }}
+              ansible.builtin.set_fact:
+                kube_cluster_groups: "{{ group_names | select('match', '^kube_') | list }}"
+
+            - name: Fail when cluster group cannot be determined
+              ansible.builtin.fail:
+                msg: >-
+                  Unable to determine the cluster grouping for {{ inventory_hostname }}. Ensure the
+                  host belongs to a group prefixed with "kube_" so that a control-plane delegate can
+                  be selected.
+              when: (kube_cluster_groups | length) == 0
+
+            - name: Record primary cluster group for delegation
+              when: (kube_cluster_groups | length) > 0
+              ansible.builtin.set_fact:
+                kube_cluster_group: "{{ kube_cluster_groups[0] }}"
+
+            - name: Choose control-plane delegate for kubectl commands
+              ansible.builtin.set_fact:
+                kube_kubectl_delegate: "{{ kube_kubectl_delegate | default(item) }}"
+              loop: "{{ groups[kube_cluster_group] | default([]) }}"
+              loop_control:
+                label: "{{ item }}"
+              when: hostvars[item].controlplane | default(false) | bool
+
+            - name: Fail if no control-plane delegate was discovered
+              ansible.builtin.fail:
+                msg: >-
+                  Unable to locate a control-plane host with kubectl access for {{ inventory_hostname }}
+                  in group {{ kube_cluster_group | default('unknown') }}.
+              when: kube_kubectl_delegate is not defined
+
         - name: Capture node scheduling state before maintenance
           ansible.builtin.include_tasks:
             file: tasks/node/get_cordon_status.yml

--- a/playbooks/tasks/node/cordon.yml
+++ b/playbooks/tasks/node/cordon.yml
@@ -6,6 +6,7 @@
       - kubectl
       - cordon
       - "{{ kube_node_name | default(inventory_hostname) }}"
+  delegate_to: "{{ kube_kubectl_delegate | default(inventory_hostname) }}"
   register: kube_node_cordon_result
   changed_when: true
   failed_when: kube_node_cordon_result.rc != 0

--- a/playbooks/tasks/node/drain.yml
+++ b/playbooks/tasks/node/drain.yml
@@ -8,6 +8,7 @@
       - "{{ kube_node_name | default(inventory_hostname) }}"
       - --ignore-daemonsets
       - --delete-emptydir-data
+  delegate_to: "{{ kube_kubectl_delegate | default(inventory_hostname) }}"
   register: kube_node_drain_result
   changed_when: true
   failed_when: kube_node_drain_result.rc != 0

--- a/playbooks/tasks/node/get_cordon_status.yml
+++ b/playbooks/tasks/node/get_cordon_status.yml
@@ -9,6 +9,7 @@
       - "{{ kube_node_name | default(inventory_hostname) }}"
       - -o
       - jsonpath={.spec.unschedulable}
+  delegate_to: "{{ kube_kubectl_delegate | default(inventory_hostname) }}"
   register: kube_node_cordon_status
   changed_when: false
   failed_when: kube_node_cordon_status.rc != 0

--- a/playbooks/tasks/node/uncordon.yml
+++ b/playbooks/tasks/node/uncordon.yml
@@ -6,6 +6,7 @@
       - kubectl
       - uncordon
       - "{{ kube_node_name | default(inventory_hostname) }}"
+  delegate_to: "{{ kube_kubectl_delegate | default(inventory_hostname) }}"
   register: kube_node_uncordon_result
   changed_when: true
   failed_when: kube_node_uncordon_result.rc != 0


### PR DESCRIPTION
## Summary
- delegate maintenance kubectl commands from worker nodes to a control-plane host in the same cluster
- add guard rails that surface missing cluster assignments or delegates during worker maintenance runs
- document the delegation behaviour and adjust the tooling requirements accordingly

## Testing
- ansible-lint playbooks/maintenance.yml
- ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --syntax-check


------
https://chatgpt.com/codex/tasks/task_e_68dbf484fe048323ac5f8a5659ec28c5