### PR TITLE
Add safeguards and readiness checks for maintenance playbook

### DIFF
--- a/playbooks/maintenance.yml
+++ b/playbooks/maintenance.yml
@@ -4,6 +4,12 @@
   become: true
   serial: 1
   any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
+  environment:
+    KUBECONFIG: /etc/rancher/rke2/rke2.yaml
+    PATH: "/var/lib/rancher/rke2/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
+  pre_tasks:
+    - name: Validate cluster scope before maintenance
+      ansible.builtin.import_tasks: tasks/common/ensure_single_cluster.yml
   tasks:
     - name: Run maintenance workflow for server nodes
       block: &node_maintenance_workflow
@@ -58,6 +64,12 @@
   become: true
   serial: 1
   any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
+  environment:
+    KUBECONFIG: /etc/rancher/rke2/rke2.yaml
+    PATH: "/var/lib/rancher/rke2/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
+  pre_tasks:
+    - name: Validate cluster scope before maintenance
+      ansible.builtin.import_tasks: tasks/common/ensure_single_cluster.yml
   tasks:
     - name: Ensure server group mapping is defined
       ansible.builtin.fail:

--- a/playbooks/tasks/common/ensure_single_cluster.yml
+++ b/playbooks/tasks/common/ensure_single_cluster.yml
@@ -1,0 +1,24 @@
+---
+- name: Ensure kube_cluster is defined for all targeted hosts
+  ansible.builtin.assert:
+    that:
+      - hostvars[item].kube_cluster is defined
+    fail_msg: >-
+      kube_cluster is not defined for {{ item }}. Update the inventory or limit the play to a specific cluster before running maintenance.
+  loop: "{{ ansible_play_hosts_all }}"
+  loop_control:
+    label: "{{ item }}"
+  run_once: true
+
+- name: Ensure maintenance targets a single Kubernetes cluster
+  ansible.builtin.assert:
+    that:
+      - >-
+          (ansible_play_hosts_all
+          | map('extract', hostvars, 'kube_cluster')
+          | list
+          | unique
+          | length) == 1
+    fail_msg: >-
+      Maintenance must be limited to a single Kubernetes cluster. Use --limit or adjust your inventory to target one cluster at a time.
+  run_once: true

--- a/playbooks/tasks/common/reboot.yml
+++ b/playbooks/tasks/common/reboot.yml
@@ -6,3 +6,14 @@
     reboot_timeout: 600
     pre_reboot_delay: 0
     post_reboot_delay: 30
+
+- name: Wait for Kubernetes API to respond after reboot
+  ansible.builtin.command: kubectl get --raw=/readyz
+  register: kube_api_readiness_check
+  delegate_to: "{{ kube_kubectl_delegate | default(inventory_hostname) }}"
+  retries: 60
+  delay: 5
+  until: >-
+    kube_api_readiness_check.rc == 0 and
+    (kube_api_readiness_check.stdout | default('') | trim | lower) == 'ok'
+  changed_when: false


### PR DESCRIPTION
## Summary
- ensure maintenance plays run with the RKE2 kubeconfig and PATH so kubectl commands succeed reliably
- add a pre-task safeguard that fails if the play targets more than one Kubernetes cluster at a time
- wait for the Kubernetes API to respond to kubectl health checks after each reboot

## Testing
- ./scripts/setup-ansible.sh
- source .venv/bin/activate && ansible-lint playbooks/maintenance.yml
- source .venv/bin/activate && ansible-playbook --syntax-check playbooks/maintenance.yml

------
https://chatgpt.com/codex/tasks/task_e_68dc3599d2e883239d5dab05c0dceccc