### PR TITLE
Hardcode server group convention for maintenance

### DIFF
--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -6,8 +6,7 @@ make individual clusters easy to target while keeping per-host metadata minimal.
 ## Group layout
 
 - Each `kube_<name>` group represents a single RKE2 cluster.
-- Cluster groups expose helper variables such as `kube_server_group` so that agent nodes can discover their control-plane
-  delegate.
+- Every cluster sets the `kube_cluster` variable so plays can enforce that maintenance only targets one cluster at a time.
 - Inside each cluster the `server` and `agent` child groups keep control-plane and worker nodes separate without introducing
   extra per-cluster helper groups.
 
@@ -19,7 +18,6 @@ all:
     kube_alpha:
       vars:
         kube_cluster: kube_alpha
-        kube_server_group: server
       children:
         server:
           hosts:

--- a/docs/MAINTENANCE_PLAYBOOK.md
+++ b/docs/MAINTENANCE_PLAYBOOK.md
@@ -7,8 +7,8 @@ that re-use the same task sequence while leveraging the inventory's `server` and
 
 1. **Server play** – Targets the inventory `server` group, ensuring control-plane nodes are serviced first. With `serial: 1` the
    play finishes maintenance on one server before moving on to the next.
-2. **Agent play** – Runs the same sequence for worker nodes. Each host discovers the appropriate server delegate using the
-   `kube_server_group` variable defined in the inventory.
+2. **Agent play** – Runs the same sequence for worker nodes. Each host discovers the appropriate server delegate by intersecting
+   the inventory `server` group with the hosts that share its `kube_cluster` value.
 
 The separation into two plays keeps the orchestration logic obvious while the inventory grouping removes the need for per-host
 flags or manual filtering.

--- a/inventories/hosts.yml
+++ b/inventories/hosts.yml
@@ -1,10 +1,11 @@
+# Each cluster group sets kube_cluster so maintenance plays can verify
+# that only one Kubernetes cluster is targeted at a time.
 ---
 all:
   children:
     kube_alpha:
       vars:
         kube_cluster: kube_alpha
-        kube_server_group: server
       children:
         server:
           hosts:
@@ -15,7 +16,6 @@ all:
     kube_bravo:
       vars:
         kube_cluster: kube_bravo
-        kube_server_group: server
       children:
         server:
           hosts:
@@ -26,7 +26,6 @@ all:
     kube_charlie:
       vars:
         kube_cluster: kube_charlie
-        kube_server_group: server
       children:
         server:
           hosts:

--- a/playbooks/maintenance.yml
+++ b/playbooks/maintenance.yml
@@ -71,24 +71,26 @@
     - name: Validate cluster scope before maintenance
       ansible.builtin.import_tasks: tasks/common/ensure_single_cluster.yml
   tasks:
-    - name: Ensure server group mapping is defined
-      ansible.builtin.fail:
-        msg: >-
-          kube_server_group is not defined for {{ inventory_hostname }}. Update the inventory so agent nodes know which
-          server group to delegate kubectl operations to.
-      when: kube_server_group is not defined
-
-    - name: Determine kubectl delegate for agent nodes
+    - name: Determine available server delegates for this cluster
       ansible.builtin.set_fact:
-        kube_kubectl_delegate: "{{ groups[kube_server_group][0] }}"
-      when: kube_server_group is defined and (groups[kube_server_group] | default([])) | length > 0
+        kube_cluster_server_candidates: >-
+          {{
+            (groups['server'] | default([]))
+            | intersect(groups[kube_cluster] | default([]))
+          }}
 
     - name: Fail when no server delegate is available for the agent
       ansible.builtin.fail:
         msg: >-
-          Unable to locate a server host for {{ inventory_hostname }} in group {{ kube_server_group | default('undefined') }}.
-          Ensure the inventory contains at least one server node for each cluster.
-      when: (groups[kube_server_group] | default([])) | length == 0
+          Unable to locate a server host for {{ inventory_hostname }} in the server group using the
+          kube_cluster convention. Ensure the inventory contains at least one server node for the
+          {{ kube_cluster | default('undefined') }} cluster.
+      when: (kube_cluster_server_candidates | default([])) | length == 0
+
+    - name: Determine kubectl delegate for agent nodes
+      ansible.builtin.set_fact:
+        kube_kubectl_delegate: "{{ kube_cluster_server_candidates[0] }}"
+      when: (kube_cluster_server_candidates | default([])) | length > 0
 
     - name: Run maintenance workflow for agent nodes
       block: *node_maintenance_workflow


### PR DESCRIPTION
## Summary
- clarify the kube_cluster inventory variable and remove kube_server_group declarations
- update maintenance playbook to derive the kubectl delegate from the server group convention
- refresh documentation to describe the new delegation behaviour

## Testing
- ansible-lint playbooks/maintenance.yml
- ansible-playbook -i inventories/hosts.yml playbooks/maintenance.yml --syntax-check

------
https://chatgpt.com/codex/tasks/task_e_68dc387914208323ae2307a015492303