### PR TITLE
Add schema-based inventory validation

### DIFF
--- a/AGENTS.yaml
+++ b/AGENTS.yaml
@@ -1,0 +1,4 @@
+notes:
+  - scope: inventories
+    message: >-
+      When modifying files under inventories/, run `python scripts/validate_inventory.py` to validate the rendered inventory before committing.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ ansible-playbook -i inventories/hosts.yml playbooks/maintenance.yml --limit "kub
 ## Verification
 
 After making changes to the playbooks or inventory, run the following commands from an activated virtual environment to ensure
-the content remains valid:
+the content remains valid. When modifying `inventories/hosts.yml`, validate the rendered inventory against the schema before
+committing so structural regressions are caught early:
 
 ```bash
+# Verify inventory structure matches the required schema
+python scripts/validate_inventory.py
+
 # Validate the inventory loads correctly
 ansible-inventory -i inventories/hosts.yml --graph
 

--- a/schemas/inventory.schema.json
+++ b/schemas/inventory.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/inventory.schema.json",
+  "title": "Kubernetes inventory schema",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "hostsConstraint": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        {
+          "type": "object",
+          "minProperties": 1
+        }
+      ]
+    },
+    "hostsGroup": {
+      "type": "object",
+      "properties": {
+        "hosts": {
+          "$ref": "#/definitions/hostsConstraint"
+        }
+      },
+      "required": [
+        "hosts"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "patternProperties": {
+    "^kube_": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "object",
+          "properties": {
+            "server": {
+              "$ref": "#/definitions/hostsGroup"
+            },
+            "agent": {
+              "type": "object",
+              "properties": {
+                "hosts": {
+                  "$ref": "#/definitions/hostsConstraint"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "required": [
+            "server"
+          ],
+          "additionalProperties": true
+        }
+      },
+      "required": [
+        "children"
+      ],
+      "additionalProperties": true
+    }
+  }
+}

--- a/scripts/setup-ansible.sh
+++ b/scripts/setup-ansible.sh
@@ -15,7 +15,7 @@ python3 -m venv "${VENV_DIR}"
 source "${VENV_DIR}/bin/activate"
 
 pip install --upgrade pip
-pip install --upgrade ansible ansible-lint
+pip install --upgrade ansible ansible-lint jsonschema
 
 echo "Virtual environment created at ${VENV_DIR}" >&2
 echo "Activate it with: source ${VENV_DIR}/bin/activate" >&2

--- a/scripts/validate_inventory.py
+++ b/scripts/validate_inventory.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate the expanded Ansible inventory against the Kubernetes schema."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+def load_inventory(inventory_path: Path) -> dict:
+    """Run ansible-inventory and return the parsed JSON data."""
+    command = [
+        "ansible-inventory",
+        "-i",
+        str(inventory_path),
+        "--list",
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise RuntimeError(
+            "ansible-inventory is not available. Install Ansible or activate the "
+            "project virtual environment before running validation."
+        ) from error
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(
+            "ansible-inventory failed to render the inventory.\n"
+            f"Command: {' '.join(command)}\n"
+            f"stdout:\n{error.stdout}\n"
+            f"stderr:\n{error.stderr}"
+        ) from error
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            "ansible-inventory did not return valid JSON output."
+        ) from error
+
+
+def validate_inventory(data: dict, schema_path: Path) -> None:
+    """Validate the inventory data against the JSON schema."""
+    schema = json.loads(schema_path.read_text())
+    validator = Draft202012Validator(schema)
+
+    errors = sorted(validator.iter_errors(data), key=lambda error: error.path)
+    if errors:
+        messages = [
+            f"Validation error at {'/'.join(map(str, error.path)) or '<root>'}: {error.message}"
+            for error in errors
+        ]
+        raise RuntimeError("\n".join(messages))
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    inventory_path = repo_root / "inventories" / "hosts.yml"
+    schema_path = repo_root / "schemas" / "inventory.schema.json"
+
+    try:
+        inventory = load_inventory(inventory_path)
+        validate_inventory(inventory, schema_path)
+    except RuntimeError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    print("Inventory validation succeeded.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a JSON schema that verifies each kube_* group exposes server hosts and optionally agent hosts
- provide a validation script that renders the inventory via ansible-inventory and checks it against the schema
- document the validation workflow and install jsonschema via the setup script so the tooling is available
- note in AGENTS.yaml that inventory contributors must run the validation script

## Testing
- python scripts/validate_inventory.py *(fails: ansible-inventory is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3cdbba508323bcd19c0a34d0bd27