### PR TITLE
Label control-plane nodes directly in cluster groups

### DIFF
--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -7,8 +7,9 @@ make individual clusters easy to target while keeping per-host metadata minimal.
 
 - Each `kube_<name>` group represents a single RKE2 cluster.
 - Every cluster sets the `kube_cluster` variable so plays can enforce that maintenance only targets one cluster at a time.
-- Inside each cluster the `server` and `agent` child groups keep control-plane and worker nodes separate without introducing
-  extra per-cluster helper groups.
+- Each cluster lists every node directly under its `hosts` key while setting `kube_cluster` so host variables inherit the
+  cluster name.
+- Control-plane nodes inside a cluster set `kube_control_plane: true`. Worker nodes omit the flag.
 
 Example excerpt:
 
@@ -18,23 +19,22 @@ all:
     kube_alpha:
       vars:
         kube_cluster: kube_alpha
-      children:
-        server:
-          hosts:
-            kube01:
-            kube02:
-            kube03:
-        agent:
-          hosts:
-            kube04:
-            kube05:
+      hosts:
+        kube01:
+          kube_control_plane: true
+        kube02:
+          kube_control_plane: true
+        kube03:
+          kube_control_plane: true
+        kube04:
+        kube05:
 ```
 
 ## Targeting hosts
 
 - **Cluster:** `ansible-playbook -i inventories/hosts.yml playbooks/maintenance.yml --limit kube_alpha`
 - **Single host:** `ansible-playbook -i inventories/hosts.yml playbooks/maintenance.yml --limit kube02`
-- **Server or agent subset:** Use `--limit server` or `--limit agent` alongside the cluster limit to run only part of the fleet.
 
-When creating new clusters, copy an existing section and adjust the hostnames. Keep the naming consistent to simplify filtering
-and monitoring.
+The maintenance playbook automatically distinguishes between control-plane and worker roles by checking the
+`kube_control_plane` host variable, so no additional helper groups are required. When creating new clusters, copy an existing
+section and adjust the hostnames. Keep the naming consistent to simplify filtering and monitoring.

--- a/inventories/hosts.yml
+++ b/inventories/hosts.yml
@@ -6,30 +6,36 @@ all:
     kube_alpha:
       vars:
         kube_cluster: kube_alpha
-      children:
-        server:
-          hosts:
-            "kube[01:03]":
-        agent:
-          hosts:
-            "kube[04:05]":
+      hosts:
+        kube01:
+          kube_control_plane: true
+        kube02:
+          kube_control_plane: true
+        kube03:
+          kube_control_plane: true
+        kube04:
+        kube05:
     kube_bravo:
       vars:
         kube_cluster: kube_bravo
-      children:
-        server:
-          hosts:
-            "kube[06:08]":
-        agent:
-          hosts:
-            "kube[09:10]":
+      hosts:
+        kube06:
+          kube_control_plane: true
+        kube07:
+          kube_control_plane: true
+        kube08:
+          kube_control_plane: true
+        kube09:
+        kube10:
     kube_charlie:
       vars:
         kube_cluster: kube_charlie
-      children:
-        server:
-          hosts:
-            "kube[11:13]":
-        agent:
-          hosts:
-            "kube[14:15]":
+      hosts:
+        kube11:
+          kube_control_plane: true
+        kube12:
+          kube_control_plane: true
+        kube13:
+          kube_control_plane: true
+        kube14:
+        kube15:

--- a/playbooks/maintenance.yml
+++ b/playbooks/maintenance.yml
@@ -1,6 +1,6 @@
 ---
 - name: Maintenance on rke2 server nodes
-  hosts: server
+  hosts: all
   become: true
   serial: 1
   any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
@@ -10,6 +10,10 @@
   pre_tasks:
     - name: Validate cluster scope before maintenance
       ansible.builtin.import_tasks: tasks/common/ensure_single_cluster.yml
+
+    - name: Skip non-control-plane nodes for server maintenance
+      when: not (kube_control_plane | default(false) | bool)
+      ansible.builtin.meta: end_host
   tasks:
     - name: Run maintenance workflow for server nodes
       block: &node_maintenance_workflow
@@ -50,7 +54,7 @@
             file: tasks/node/uncordon.yml
 
 - name: Maintenance on rke2 agent nodes
-  hosts: agent
+  hosts: all
   become: true
   serial: 1
   any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
@@ -60,21 +64,28 @@
   pre_tasks:
     - name: Validate cluster scope before maintenance
       ansible.builtin.import_tasks: tasks/common/ensure_single_cluster.yml
+
+    - name: Skip control-plane nodes for agent maintenance
+      when: kube_control_plane | default(false) | bool
+      ansible.builtin.meta: end_host
   tasks:
     - name: Determine available server delegates for this cluster
       ansible.builtin.set_fact:
         kube_cluster_server_candidates: >-
           {{
-            (groups['server'] | default([]))
-            | intersect(groups[kube_cluster] | default([]))
+            (hostvars | dict2items)
+            | selectattr('key', 'in', groups[kube_cluster] | default([]))
+            | selectattr('value.kube_control_plane', 'defined')
+            | selectattr('value.kube_control_plane')
+            | map(attribute='key')
+            | list
           }}
 
     - name: Fail when no server delegate is available for the agent
       ansible.builtin.fail:
         msg: >-
-          Unable to locate a server host for {{ inventory_hostname }} in the server group using the
-          kube_cluster convention. Ensure the inventory contains at least one server node for the
-          {{ kube_cluster | default('undefined') }} cluster.
+          Unable to locate a control-plane host for {{ inventory_hostname }} in the {{ kube_cluster | default('undefined') }}
+          cluster. Ensure the inventory defines at least one server node with kube_control_plane: true.
       when: (kube_cluster_server_candidates | default([])) | length == 0
 
     - name: Determine kubectl delegate for agent nodes

--- a/schemas/inventory.schema.json
+++ b/schemas/inventory.schema.json
@@ -5,6 +5,15 @@
   "type": "object",
   "additionalProperties": true,
   "definitions": {
+    "hostVars": {
+      "type": "object",
+      "properties": {
+        "kube_control_plane": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
     "hostsConstraint": {
       "anyOf": [
         {
@@ -16,7 +25,17 @@
         },
         {
           "type": "object",
-          "minProperties": 1
+          "minProperties": 1,
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/definitions/hostVars"
+              }
+            ]
+          }
         }
       ]
     },
@@ -34,35 +53,8 @@
     }
   },
   "patternProperties": {
-    "^kube_": {
-      "type": "object",
-      "properties": {
-        "children": {
-          "type": "object",
-          "properties": {
-            "server": {
-              "$ref": "#/definitions/hostsGroup"
-            },
-            "agent": {
-              "type": "object",
-              "properties": {
-                "hosts": {
-                  "$ref": "#/definitions/hostsConstraint"
-                }
-              },
-              "additionalProperties": true
-            }
-          },
-          "required": [
-            "server"
-          ],
-          "additionalProperties": true
-        }
-      },
-      "required": [
-        "children"
-      ],
-      "additionalProperties": true
+    "^kube_[a-z]+$": {
+      "$ref": "#/definitions/hostsGroup"
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove the global server/agent groups and mark control-plane hosts inline within each cluster
- adjust the maintenance play to filter hosts by kube_control_plane metadata and choose kubectl delegates from the same cluster
- document the streamlined structure and extend the inventory schema to validate the new host variable layout

## Testing
- source .venv/bin/activate
- python scripts/validate_inventory.py
- ansible-lint playbooks/maintenance.yml
- ansible-playbook -i inventories/hosts.yml playbooks/maintenance.yml --syntax-check
- deactivate

------
https://chatgpt.com/codex/tasks/task_e_68dce1d69eec8323ba4ee51196b72527