### PR TITLE
Add drain timeouts and document recovery steps

### DIFF
--- a/docs/MAINTENANCE_PLAYBOOK.md
+++ b/docs/MAINTENANCE_PLAYBOOK.md
@@ -35,3 +35,19 @@ Each command task has explicit `failed_when` rules so that unexpected return cod
 - When a new maintenance action requires additional variables, document them in the task file and consider providing defaults in `group_vars`.
 
 Keeping the main playbook compact and delegating the implementation to a shared task file preserves readability while making it straightforward to add new capabilities.
+
+## Troubleshooting stuck drains
+
+`kubectl drain` can wait indefinitely when pods refuse eviction. The playbook now exposes several variables to tune that behaviour:
+
+- `kube_drain_include_daemonsets` (default: `false`) – When set to `true` the command renders `--ignore-daemonsets=false`, which forces the drain to wait for daemonset-managed pods. Because daemonsets are typically recreated immediately, the drain will appear to hang unless the daemonset is scaled to zero first.
+- `kube_drain_delete_emptydir_data` (default: `true`) – Enables `--delete-emptydir-data` so pods using `emptyDir` volumes are terminated instead of blocking the drain.
+- `kube_drain_timeout` (default: `10m`) – Maps to the native `--timeout` flag on `kubectl drain` to abort the operation when the grace period expires. The timeout must include a unit (e.g. `5m`, `30s`).
+- `kube_kubectl_command_timeout` (default: `900`) – Caps the runtime of every delegated `kubectl` invocation to prevent the Ansible task itself from running forever if the client hangs or loses connectivity.
+
+When a drain times out or hangs, take the following recovery steps:
+
+1. Inspect which pods are blocking the drain with `kubectl get pods -A --field-selector spec.nodeName=<node> -o wide`. Daemonset pods must be deleted by scaling the owning daemonset to zero or by temporarily disabling the drain option that includes them.
+2. Check for pod disruption budgets (`kubectl get pdb -A`) that may prevent voluntary disruption. Temporarily raise their `maxUnavailable` or delete them while maintenance is in progress.
+3. If the playbook aborted midway, run `kubectl uncordon <node>` to restore scheduling and return the cluster to a healthy state before retrying.
+4. After resolving the blockers, rerun the maintenance play. The drain task will respect the configured timeouts and fail fast when pods are still preventing eviction, allowing manual intervention without leaving the node cordoned indefinitely.

--- a/playbooks/tasks/node/cordon.yml
+++ b/playbooks/tasks/node/cordon.yml
@@ -10,6 +10,7 @@
   register: kube_node_cordon_result
   changed_when: true
   failed_when: kube_node_cordon_result.rc != 0
+  timeout: "{{ kube_kubectl_command_timeout | default(300) }}"
 
 - name: Update cached cordon status for {{ kube_node_name | default(inventory_hostname) }}
   ansible.builtin.set_fact:

--- a/playbooks/tasks/node/drain.yml
+++ b/playbooks/tasks/node/drain.yml
@@ -1,14 +1,16 @@
 ---
-# Drain workloads from a Kubernetes node while tolerating daemonsets and emptyDir data.
+# Drain workloads from a Kubernetes node with configurable daemonset and emptyDir handling.
 - name: Drain {{ kube_node_name | default(inventory_hostname) }}
   ansible.builtin.command:
     argv:
       - kubectl
       - drain
       - "{{ kube_node_name | default(inventory_hostname) }}"
-      - --ignore-daemonsets
-      - --delete-emptydir-data
+      - "--ignore-daemonsets={{ (kube_drain_include_daemonsets | default(false) | bool) | ternary('false', 'true') }}"
+      - "--delete-emptydir-data={{ (kube_drain_delete_emptydir_data | default(true) | bool) | ternary('true', 'false') }}"
+      - "--timeout={{ kube_drain_timeout | default('10m') }}"
   delegate_to: "{{ kube_kubectl_delegate | default(inventory_hostname) }}"
   register: kube_node_drain_result
   changed_when: true
   failed_when: kube_node_drain_result.rc != 0
+  timeout: "{{ kube_kubectl_command_timeout | default(900) }}"

--- a/playbooks/tasks/node/get_cordon_status.yml
+++ b/playbooks/tasks/node/get_cordon_status.yml
@@ -13,6 +13,7 @@
   register: kube_node_cordon_status
   changed_when: false
   failed_when: kube_node_cordon_status.rc != 0
+  timeout: "{{ kube_kubectl_command_timeout | default(120) }}"
 
 - name: Cache schedulability fact for {{ kube_node_name | default(inventory_hostname) }}
   ansible.builtin.set_fact:

--- a/playbooks/tasks/node/uncordon.yml
+++ b/playbooks/tasks/node/uncordon.yml
@@ -10,6 +10,7 @@
   register: kube_node_uncordon_result
   changed_when: true
   failed_when: kube_node_uncordon_result.rc != 0
+  timeout: "{{ kube_kubectl_command_timeout | default(300) }}"
 
 - name: Update cached cordon status for {{ kube_node_name | default(inventory_hostname) }}
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
- add configurable kubectl drain flags for daemonsets, emptyDir volumes, and timeout handling
- enforce timeouts on all kubectl command tasks to prevent indefinite hangs
- document how to troubleshoot and recover from stuck drains in the maintenance playbook guide

## Testing
- ansible-lint playbooks/maintenance.yml
- ansible-playbook playbooks/maintenance.yml --syntax-check

------
https://chatgpt.com/codex/tasks/task_e_68dd2812f9ec8323ab3926edc9eda4e1