### PR TITLE
Simplify control plane detection in maintenance playbook

### DIFF
--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -31,4 +31,4 @@ kube05
 - **Cluster:** `ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --limit kube_alpha`
 - **Single host:** `ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --limit kube02`
 
-The maintenance playbook automatically distinguishes between control-plane and worker roles by checking the `controlplane` host variable (falling back to `kube_control_plane` for legacy inventories), so no additional helper groups are required. When creating new clusters, copy an existing section and adjust the hostnames. Keep the naming consistent to simplify filtering and monitoring.
+The maintenance playbook automatically distinguishes between control-plane and worker roles by checking the `controlplane` host variable, so no additional helper groups are required. When creating new clusters, copy an existing section and adjust the hostnames. Keep the naming consistent to simplify filtering and monitoring.

--- a/playbooks/maintenance.yml
+++ b/playbooks/maintenance.yml
@@ -5,7 +5,7 @@
   serial: 1
   any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
   vars:
-    kube_node_is_control_plane: "{{ controlplane | default(kube_control_plane) | default(false) | bool }}"
+    kube_node_is_control_plane: "{{ controlplane | default(false) | bool }}"
   environment:
     KUBECONFIG: /etc/rancher/rke2/rke2.yaml
     PATH: "/var/lib/rancher/rke2/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
@@ -61,7 +61,7 @@
   serial: 1
   any_errors_fatal: true  # Halt the play entirely if any task fails to allow manual debugging
   vars:
-    kube_node_is_control_plane: "{{ controlplane | default(kube_control_plane) | default(false) | bool }}"
+    kube_node_is_control_plane: "{{ controlplane | default(false) | bool }}"
   environment:
     KUBECONFIG: /etc/rancher/rke2/rke2.yaml
     PATH: "/var/lib/rancher/rke2/bin:{{ ansible_env.PATH | default('/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin') }}"
@@ -78,22 +78,11 @@
         kube_cluster_server_candidates: >-
           {{
             (
-              (
-                (hostvars | dict2items)
-                | selectattr('key', 'in', groups[kube_cluster] | default([]))
-                | selectattr('value.controlplane', 'defined')
-                | selectattr('value.controlplane')
-                | map(attribute='key')
-              )
-              +
-              (
-                (hostvars | dict2items)
-                | selectattr('key', 'in', groups[kube_cluster] | default([]))
-                | selectattr('value.controlplane', 'undefined')
-                | selectattr('value.kube_control_plane', 'defined')
-                | selectattr('value.kube_control_plane')
-                | map(attribute='key')
-              )
+              (hostvars | dict2items)
+              | selectattr('key', 'in', groups[kube_cluster] | default([]))
+              | selectattr('value.controlplane', 'defined')
+              | selectattr('value.controlplane')
+              | map(attribute='key')
             )
             | unique
             | list


### PR DESCRIPTION
## Summary
- remove the unused kube_control_plane fallback from the maintenance workflow
- simplify the control-plane delegate discovery to rely solely on the controlplane host var
- update the inventory documentation to reflect the streamlined behaviour

## Testing
- ansible-lint playbooks/maintenance.yml
- ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --syntax-check

------
https://chatgpt.com/codex/tasks/task_e_68dd342270cc8323bb81ade3fd666131