### PR TITLE
Use dnf module for system updates

### DIFF
--- a/playbooks/tasks/common/dnf_update.yml
+++ b/playbooks/tasks/common/dnf_update.yml
@@ -1,21 +1,14 @@
 ---
-- name: Check for available system updates
-  ansible.builtin.command:
-    argv:
-      - dnf
-      - -q
-      - check-update
-  register: dnf_check_result
-  changed_when: false
-  failed_when: dnf_check_result.rc not in [0, 100]
+- name: Apply system updates with DNF
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest
+    update_cache: true
+    update_only: true
+  register: dnf_update_result
 
-- name: Apply system updates
-  when: dnf_check_result.rc == 100
-  ansible.builtin.command:
-    argv:
-      - dnf
-      - -y
-      - upgrade
-  register: dnf_upgrade_result
-  changed_when: true
-  failed_when: dnf_upgrade_result.rc != 0
+- name: Report updated packages
+  ansible.builtin.debug:
+    msg: >-
+      Updated packages: {{ (dnf_update_result.results | default([])) | map(attribute='name') | list | join(', ') }}
+  when: dnf_update_result.changed and (dnf_update_result.results | default([])) | length > 0


### PR DESCRIPTION
## Summary
- replace the raw `dnf` command invocations with the `ansible.builtin.dnf` module for package maintenance
- emit a concise summary of updated packages when changes occur

## Testing
- ./scripts/setup-ansible.sh
- source .venv/bin/activate
- ansible-lint playbooks/maintenance.yml
- ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --syntax-check


------
https://chatgpt.com/codex/tasks/task_e_68dd4626725c83239091e2a3b98c1bb0