### PR TITLE
Remove DNF update reporting task

### DIFF
--- a/playbooks/tasks/common/dnf_update.yml
+++ b/playbooks/tasks/common/dnf_update.yml
@@ -6,9 +6,3 @@
     update_cache: true
     update_only: true
   register: dnf_update_result
-
-- name: Report updated packages
-  ansible.builtin.debug:
-    msg: >-
-      Updated packages: {{ (dnf_update_result.results | default([])) | map(attribute='name') | list | join(', ') }}
-  when: dnf_update_result.changed and (dnf_update_result.results | default([])) | length > 0


### PR DESCRIPTION
## Summary
- remove debug reporting of updated packages from the DNF update task to prevent check mode issues

## Testing
- ansible-lint playbooks/maintenance.yml
- ansible-playbook playbooks/maintenance.yml --syntax-check

------
https://chatgpt.com/codex/tasks/task_e_68de548c867883238aafcc5e4fa4ffe0