### PR TITLE
Collect Longhorn diagnostics in trace kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ The play creates a timestamped archive under `artifacts/trace-kit/` containing p
 events, pod logs (including CNI, kube-proxy, and CoreDNS), optional workload restarts, and workload manifests for reproducing
 failures in a test environment.
 
+When Longhorn is installed, trace kit gathers detailed diagnostics under `cluster/longhorn/`. It records high-level status
+tables for volumes, replicas, engines, nodes, share managers, and PersistentVolumes, captures the underlying custom resource
+manifests, and stores namespace events alongside `kubectl describe` output for every Longhorn pod. The role also tails pod
+logs grouped by component so you can quickly inspect manager, driver deployer, webhook, or instance manager activity. To help
+surface storage issues, the run highlights PersistentVolumes stuck in problematic phases (`Pending`, `Available`, `Released`,
+or `Failed`) or terminating and preserves both their manifests and `kubectl describe` output for root-cause analysis. Tune
+the behaviour with variables such as `trace_kit_capture_longhorn`, `trace_kit_longhorn_namespace`,
+`trace_kit_longhorn_status_commands`, `trace_kit_longhorn_resource_types`, `trace_kit_longhorn_trace_components`, and
+`trace_kit_longhorn_problematic_pv_phases`.
+
 #### Reproducing failed workloads in a test cluster
 
 1. Extract the generated tarball on your workstation:

--- a/roles/trace_kit/defaults/main.yml
+++ b/roles/trace_kit/defaults/main.yml
@@ -11,6 +11,63 @@ trace_kit_traceroute_options: "-n"
 trace_kit_curl_extra_args: "--fail --location --silent --show-error --output /dev/null"
 trace_kit_curl_format: "http_code=%{http_code} total_time=%{time_total} connect_time=%{time_connect}"
 
+# Longhorn diagnostics collection.
+trace_kit_capture_longhorn: true
+trace_kit_longhorn_namespace: longhorn-system
+trace_kit_longhorn_log_tail_lines: 500
+trace_kit_longhorn_status_commands:
+  - name: pods
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get pods -o wide"
+  - name: volumes
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get volumes.longhorn.io -o wide"
+  - name: nodes
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get nodes.longhorn.io -o wide"
+  - name: engines
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get engines.longhorn.io -o wide"
+  - name: replicas
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get replicas.longhorn.io -o wide"
+  - name: sharemanagers
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get sharemanagers.longhorn.io -o wide"
+  - name: persistentvolumes
+    command: "kubectl get pv -o wide"
+trace_kit_longhorn_resource_types:
+  - volumes.longhorn.io
+  - engines.longhorn.io
+  - replicas.longhorn.io
+  - instance-managers.longhorn.io
+  - sharemanagers.longhorn.io
+  - backingimagemanagers.longhorn.io
+  - backingimagedatasources.longhorn.io
+  - nodes.longhorn.io
+  - settings.longhorn.io
+  - recurringjobs.longhorn.io
+trace_kit_longhorn_trace_components:
+  - name: manager
+    selector: "app=longhorn-manager"
+  - name: driver-deployer
+    selector: "app=longhorn-driver-deployer"
+  - name: ui
+    selector: "app=longhorn-ui"
+  - name: conversion-webhook
+    selector: "app=longhorn-conversion-webhook"
+  - name: admission-webhook
+    selector: "app=longhorn-admission-webhook"
+  - name: recovery-backend
+    selector: "app=longhorn-recovery-backend"
+  - name: instance-manager
+    selector: "longhorn.io/component=instance-manager"
+  - name: backing-image-manager
+    selector: "longhorn.io/component=backing-image-manager"
+  - name: share-manager
+    selector: "longhorn.io/component=share-manager"
+  - name: support-bundle-manager
+    selector: "longhorn.io/component=support-bundle-manager"
+trace_kit_longhorn_problematic_pv_phases:
+  - Pending
+  - Available
+  - Released
+  - Failed
+
 # Namespace specific verification.
 trace_kit_flagged_namespaces: []
 

--- a/roles/trace_kit/tasks/cluster.yml
+++ b/roles/trace_kit/tasks/cluster.yml
@@ -16,6 +16,7 @@
     - reproduction
     - cilium
     - envoy-gateway
+    - longhorn
 
 - name: Create reproduction data directories
   ansible.builtin.file:
@@ -43,6 +44,18 @@
   loop:
     - routes
 
+- name: Create Longhorn diagnostics directories
+  ansible.builtin.file:
+    path: "{{ trace_kit_cluster_dir }}/longhorn/{{ item }}"
+    state: directory
+    mode: "0750"
+  loop:
+    - status
+    - resources
+    - traces
+    - debug
+  when: trace_kit_capture_longhorn | bool
+
 - name: Capture cluster node overview
   ansible.builtin.shell: |
     set -o pipefail
@@ -67,6 +80,264 @@
     kubectl get events -A --sort-by=.lastTimestamp > "{{ trace_kit_cluster_dir }}/events.txt" 2>&1
   args:
     executable: /bin/bash
+  changed_when: true
+  failed_when: false
+
+- name: Capture Longhorn status summaries
+  ansible.builtin.shell: |
+    set -o pipefail
+    {
+      echo "# {{ item.command }}"
+      {{ item.command }}
+    } > "{{ trace_kit_cluster_dir }}/longhorn/status/{{ item.name | regex_replace('[^A-Za-z0-9_.-]', '_') }}.txt" 2>&1 || true
+  args:
+    executable: /bin/bash
+  loop: "{{ trace_kit_longhorn_status_commands }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: trace_kit_capture_longhorn | bool
+  changed_when: true
+  failed_when: false
+
+- name: Capture Longhorn resource manifests
+  ansible.builtin.shell: |
+    set -o pipefail
+    {
+      echo "# kubectl -n {{ trace_kit_longhorn_namespace }} get {{ item }} -o yaml"
+      kubectl -n {{ trace_kit_longhorn_namespace }} get {{ item }} -o yaml
+    } > "{{ trace_kit_cluster_dir }}/longhorn/resources/{{ item | regex_replace('[^A-Za-z0-9_.-]', '_') }}.yaml" 2>&1 || true
+  args:
+    executable: /bin/bash
+  loop: "{{ trace_kit_longhorn_resource_types }}"
+  loop_control:
+    label: "{{ item }}"
+  when: trace_kit_capture_longhorn | bool
+  changed_when: true
+  failed_when: false
+
+- name: Capture Longhorn namespace events
+  ansible.builtin.shell: |
+    set -o pipefail
+    kubectl -n {{ trace_kit_longhorn_namespace }} get events --sort-by=.lastTimestamp \
+      > "{{ trace_kit_cluster_dir }}/longhorn/debug/events.txt" 2>&1 || true
+  args:
+    executable: /bin/bash
+  when: trace_kit_capture_longhorn | bool
+  changed_when: true
+  failed_when: false
+
+- name: Gather Longhorn pod names
+  ansible.builtin.shell: |
+    set -o pipefail
+    kubectl -n {{ trace_kit_longhorn_namespace }} get pods \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+  args:
+    executable: /bin/bash
+  register: trace_kit_longhorn_pod_inventory
+  when: trace_kit_capture_longhorn | bool
+  changed_when: false
+  failed_when: false
+
+- name: Describe Longhorn pods
+  ansible.builtin.shell: |
+    set -o pipefail
+    {
+      echo "# kubectl -n {{ trace_kit_longhorn_namespace }} describe pod {{ item }}"
+      kubectl -n {{ trace_kit_longhorn_namespace }} describe pod {{ item }}
+    } > "{{ trace_kit_cluster_dir }}/longhorn/debug/pod-{{ item | regex_replace('[^A-Za-z0-9_.-]', '_') }}.describe" 2>&1 || true
+  args:
+    executable: /bin/bash
+  loop: "{{ trace_kit_longhorn_pod_inventory.stdout_lines | default([]) }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - trace_kit_capture_longhorn | bool
+    - (trace_kit_longhorn_pod_inventory.stdout_lines | default([])) | length > 0
+  changed_when: true
+  failed_when: false
+
+- name: Discover Longhorn pods for log capture
+  ansible.builtin.shell: |
+    set -o pipefail
+    kubectl -n {{ trace_kit_longhorn_namespace }} get pods -l {{ item.selector }} \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+  args:
+    executable: /bin/bash
+  register: trace_kit_longhorn_trace_pods
+  loop: "{{ trace_kit_longhorn_trace_components }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: trace_kit_capture_longhorn | bool
+  changed_when: false
+  failed_when: false
+
+- name: Ensure Longhorn component trace directories exist
+  ansible.builtin.file:
+    path: "{{ trace_kit_cluster_dir }}/longhorn/traces/{{ item.name | regex_replace('[^A-Za-z0-9_.-]', '_') }}"
+    state: directory
+    mode: "0750"
+  loop: "{{ trace_kit_longhorn_trace_components }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: trace_kit_capture_longhorn | bool
+
+- name: Reset Longhorn component log targets
+  ansible.builtin.set_fact:
+    trace_kit_longhorn_log_targets: []
+  when: trace_kit_capture_longhorn | bool
+
+- name: Build Longhorn component log targets
+  ansible.builtin.set_fact:
+    trace_kit_longhorn_log_targets: >-
+      {{
+        (trace_kit_longhorn_log_targets | default([]))
+        + [
+            {
+              'component': item.0.item.name,
+              'selector': item.0.item.selector,
+              'pod': item.1
+            }
+          ]
+      }}
+  loop: >-
+    {{
+      query(
+        'subelements',
+        trace_kit_longhorn_trace_pods.results | default([]),
+        'stdout_lines',
+        {'skip_missing': True}
+      )
+    }}
+  loop_control:
+    label: "{{ item.0.item.name }}:{{ item.1 }}"
+  when: trace_kit_capture_longhorn | bool
+
+- name: Note Longhorn components without pods
+  ansible.builtin.copy:
+    dest: "{{ trace_kit_cluster_dir }}/longhorn/traces/{{ item.item.name | regex_replace('[^A-Za-z0-9_.-]', '_') }}/_info.txt"
+    content: "No pods matched selector {{ item.item.selector }}\n"
+    mode: "0640"
+  loop: "{{ trace_kit_longhorn_trace_pods.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when:
+    - trace_kit_capture_longhorn | bool
+    - (item.stdout_lines | default([])) | length == 0
+
+- name: Capture Longhorn component logs
+  ansible.builtin.shell: |
+    set -o pipefail
+    component_safe="{{ item.component | regex_replace('[^A-Za-z0-9_.-]', '_') }}"
+    pod_safe="{{ item.pod | regex_replace('[^A-Za-z0-9_.-]', '_') }}"
+    output_file="{{ trace_kit_cluster_dir }}/longhorn/traces/${component_safe}/${pod_safe}.log"
+    {
+      echo "# kubectl -n {{ trace_kit_longhorn_namespace }} logs {{ item.pod }} --all-containers --tail {{ trace_kit_longhorn_log_tail_lines }}"
+      kubectl -n {{ trace_kit_longhorn_namespace }} logs {{ item.pod }} \
+        --all-containers \
+        --tail {{ trace_kit_longhorn_log_tail_lines }} || true
+    } > "$output_file" 2>&1
+  args:
+    executable: /bin/bash
+  loop: "{{ trace_kit_longhorn_log_targets | default([]) }}"
+  loop_control:
+    label: "{{ item.component }}:{{ item.pod }}"
+  when:
+    - trace_kit_capture_longhorn | bool
+    - (trace_kit_longhorn_log_targets | default([])) | length > 0
+  changed_when: true
+  failed_when: false
+
+- name: Identify problematic PersistentVolumes
+  ansible.builtin.shell: |
+    set -o pipefail
+    output_file="{{ trace_kit_cluster_dir }}/longhorn/status/problematic-pvs.txt"
+    tmp_json="$(mktemp)"
+    tmp_err="$(mktemp)"
+    if kubectl get pv -o json >"$tmp_json" 2>"$tmp_err"; then
+      python3 - "$tmp_json" >"$output_file" -c 'import json, sys
+        phases = set({{ trace_kit_longhorn_problematic_pv_phases | to_json }})
+        path = sys.argv[1]
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+
+        matches = []
+        for item in data.get("items", []):
+            meta = item.get("metadata", {})
+            status = item.get("status", {})
+            name = meta.get("name")
+            phase = status.get("phase", "Unknown")
+            deleting = meta.get("deletionTimestamp")
+            if name and (phase in phases or deleting):
+                matches.append((name, phase, bool(deleting)))
+
+        if not matches:
+            print("# No PersistentVolumes matched the problematic phases or were terminating.")
+        else:
+            print("# name\tphase\tterminating")
+            for name, phase, deleting in matches:
+                print(f"{name}\t{phase}\t{str(deleting).lower()}")'
+    else
+      {
+        echo "# kubectl get pv -o json"
+        cat "$tmp_err"
+      } >"$output_file"
+    fi
+    cat "$output_file"
+    rm -f "$tmp_json" "$tmp_err"
+  args:
+    executable: /bin/bash
+  register: trace_kit_longhorn_problematic_pvs
+  when: trace_kit_capture_longhorn | bool
+  changed_when: false
+  failed_when: false
+
+- name: Record problematic PersistentVolume names
+  ansible.builtin.set_fact:
+    trace_kit_longhorn_problematic_pv_names: >-
+      {{
+        (trace_kit_longhorn_problematic_pv_names | default([]))
+        + [item.split('\t')[0]]
+      }}
+  loop: "{{ trace_kit_longhorn_problematic_pvs.stdout_lines | default([]) }}"
+  when:
+    - trace_kit_capture_longhorn | bool
+    - item is string
+    - item | length > 0
+    - not item.startswith('#')
+
+- name: Capture manifests for problematic PersistentVolumes
+  ansible.builtin.shell: |
+    set -o pipefail
+    {
+      echo "# kubectl get pv {{ item }} -o yaml"
+      kubectl get pv {{ item }} -o yaml
+    } > "{{ trace_kit_cluster_dir }}/longhorn/resources/pv-{{ item | regex_replace('[^A-Za-z0-9_.-]', '_') }}.yaml" 2>&1 || true
+  args:
+    executable: /bin/bash
+  loop: "{{ trace_kit_longhorn_problematic_pv_names | default([]) }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - trace_kit_capture_longhorn | bool
+    - (trace_kit_longhorn_problematic_pv_names | default([])) | length > 0
+  changed_when: true
+  failed_when: false
+
+- name: Describe problematic PersistentVolumes
+  ansible.builtin.shell: |
+    set -o pipefail
+    {
+      echo "# kubectl describe pv {{ item }}"
+      kubectl describe pv {{ item }}
+    } > "{{ trace_kit_cluster_dir }}/longhorn/debug/pv-{{ item | regex_replace('[^A-Za-z0-9_.-]', '_') }}.describe" 2>&1 || true
+  args:
+    executable: /bin/bash
+  loop: "{{ trace_kit_longhorn_problematic_pv_names | default([]) }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - trace_kit_capture_longhorn | bool
+    - (trace_kit_longhorn_problematic_pv_names | default([])) | length > 0
   changed_when: true
   failed_when: false
 

--- a/roles/trace_kit/tasks/network.yml
+++ b/roles/trace_kit/tasks/network.yml
@@ -13,7 +13,6 @@
     label: "{{ item.name | default(item.address) }}"
   when: trace_kit_targets | length > 0
   changed_when: true
-
 - name: Run ping against each target
   ansible.builtin.shell: |
     set -o pipefail


### PR DESCRIPTION
## Summary
- replace the Longhorn DNS dig capture with a full suite of cluster-level diagnostics and log collection
- default new Longhorn-specific knobs for status commands, resource manifests, component log capture, and problematic PV phases
- document the new Longhorn troubleshooting data produced by trace kit

## Testing
- ./scripts/setup-ansible.sh
- source .venv/bin/activate && ansible-lint roles/trace_kit
- source .venv/bin/activate && ANSIBLE_ROLES_PATH=roles ansible-playbook --syntax-check playbooks/trace-kit.yml


------
https://chatgpt.com/codex/tasks/task_e_68ff2ab0ba248323bbe4bc72a881d27c