### PR TITLE
Refine onboarding docs and extract trace kit guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ ansible-playbook -i inventories/hosts.ini playbooks/trace-kit.yml \
   -e @vars/trace-kit.yaml
 ```
 
-Read the [trace kit guide](docs/TRACE_KIT.md) for variable details, storage layout, and Longhorn-specific capture behaviour.
+Start by copying [`vars/trace-kit.example.yml`](vars/trace-kit.example.yml) to `vars/trace-kit.yaml` and tailor the values for
+your cluster. Read the [trace kit guide](docs/TRACE_KIT.md) for variable details, storage layout, and Longhorn-specific capture
+behaviour.
 
 ### Running ad-hoc commands
 

--- a/README.md
+++ b/README.md
@@ -34,25 +34,13 @@ See [`docs/README.md`](docs/README.md) for deep dives into playbook internals, i
 
 ## Get Started
 
-1. **Clone the repository and enter it.**
-   ```bash
-   git clone https://github.com/<org>/k8s-playbooks.git
-   cd k8s-playbooks
-   ```
-2. **Bootstrap the tooling.** Create a Python virtual environment, install Ansible, and activate the environment.
-   ```bash
-   ./scripts/setup-ansible.sh
-   source .venv/bin/activate
-   ```
-   > Set the `VENV_DIR` environment variable before running the script to change the virtual environment location.
-3. **Validate the installation and inventory.**
-   ```bash
-   ansible --version
-   ansible-lint --version
-   ansible-inventory -i inventories/hosts.ini --graph
-   ```
+The checklist below summarises the onboarding workflow. Follow the [Day 1 setup guide](docs/ONBOARDING.md#day-1-setup) for the full commands and optional flags.
 
-Keep the virtual environment activated (`source .venv/bin/activate`) in every new shell so the installed tooling remains available. Ensure the selected kubectl delegate (a control-plane host discovered during the kubectl setup helpers) can reach the Kubernetes API and has `kubectl` available in `/var/lib/rancher/rke2/bin`.
+1. Clone this repository and switch into the project directory.
+2. Run `./scripts/setup-ansible.sh` to provision the Python virtual environment and tooling.
+3. Activate the environment and confirm Ansible, ansible-lint, and the inventory load correctly.
+
+Keep the virtual environment activated (`source .venv/bin/activate`) in every new shell so the installed tooling remains available. The designated kubectl delegate (a control-plane host discovered during the kubectl helpers) must be able to reach the Kubernetes API and expose `kubectl` under `/var/lib/rancher/rke2/bin`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@
 This repository provides Ansible resources for operating Rancher Kubernetes Engine 2 (RKE2) clusters. It currently includes:
 
 - A readable INI inventory that organises hosts per cluster with dedicated control-plane and worker groups for targeted plays.
-- A rolling maintenance playbook that drains, updates, reboots, and uncordons each host one at a time, using inventory ordering
-  to service control-plane nodes before workers.
-- A GPU labelling playbook that detects NVIDIA hardware on each node and applies `gpu=on` or `gpu=off` Kubernetes labels so
-  every node is consistently marked for GPU scheduling frameworks such as [HAMi](https://github.com/Project-HAMi/HAMi).
-- A trace kit playbook that gathers multi-node network traces, cluster diagnostics, and packages the findings for
-  SRE or vendor escalation.
+- A rolling maintenance playbook that drains, updates, reboots, and uncordons each host one at a time, using inventory ordering to service control-plane nodes before workers.
+- A GPU labelling playbook that detects NVIDIA hardware on each node and applies `gpu=on` or `gpu=off` Kubernetes labels so every node is consistently marked for GPU scheduling frameworks such as [HAMi](https://github.com/Project-HAMi/HAMi).
+- A trace kit playbook that gathers multi-node network traces, cluster diagnostics, and packages the findings for SRE or vendor escalation.
+
+See [`docs/README.md`](docs/README.md) for deep dives into playbook internals, inventory conventions, and onboarding material.
 
 ## Repository layout
 
@@ -20,64 +19,52 @@ This repository provides Ansible resources for operating Rancher Kubernetes Engi
 ├── playbooks/
 │   ├── label-gpu-nodes.yml   # Apply the gpu=on label to hosts with NVIDIA hardware
 │   ├── maintenance.yml       # Entry point for the maintenance workflow
-│   ├── trace-kit.yml        # Collect in-depth diagnostics for incident response
+│   ├── trace-kit.yml         # Collect in-depth diagnostics for incident response
 │   └── tasks/
 │       └── common/           # Re-usable task snippets for maintenance actions
 └── scripts/
     └── setup-ansible.sh      # Helper script to create the tooling virtual environment
 ```
 
-See [`docs/README.md`](docs/README.md) for deep dives into the playbook internals, inventory conventions, and onboarding steps.
-
 ## Requirements
 
 - Ansible 2.12+ (tested syntax)
 - Access to the target nodes with privilege escalation (`become`)
-- `kubectl` available on control-plane nodes (worker nodes delegate Kubernetes operations to a
-  control-plane host discovered during the kubectl role's setup helpers)
+- `kubectl` available on control-plane nodes (worker nodes delegate Kubernetes operations to a control-plane host discovered during the kubectl role's setup helpers)
 
-## Local development setup
+## Get Started
 
-Set up a local Python virtual environment and install Ansible along with the linting tools used by the repository by running the
-helper script:
+1. **Clone the repository and enter it.**
+   ```bash
+   git clone https://github.com/<org>/k8s-playbooks.git
+   cd k8s-playbooks
+   ```
+2. **Bootstrap the tooling.** Create a Python virtual environment, install Ansible, and activate the environment.
+   ```bash
+   ./scripts/setup-ansible.sh
+   source .venv/bin/activate
+   ```
+   > Set the `VENV_DIR` environment variable before running the script to change the virtual environment location.
+3. **Validate the installation and inventory.**
+   ```bash
+   ansible --version
+   ansible-lint --version
+   ansible-inventory -i inventories/hosts.ini --graph
+   ```
 
-```bash
-./scripts/setup-ansible.sh
-source .venv/bin/activate
-```
-
-> The script creates a `.venv` directory in the repository by default. You can change the location by setting the `VENV_DIR`
-> environment variable before running it.
-
-Confirm the installation succeeded:
-
-```bash
-ansible --version
-ansible-lint --version
-```
-
-> **Tip:** Activate the virtual environment (`source .venv/bin/activate`) in every new shell before running the commands below so
-> that the installed tooling is available.
-
-Ensure the selected kubectl delegate (a control-plane host discovered during the kubectl setup helpers) can reach the Kubernetes API and has `kubectl` available in `/var/lib/rancher/rke2/bin`.
+Keep the virtual environment activated (`source .venv/bin/activate`) in every new shell so the installed tooling remains available. Ensure the selected kubectl delegate (a control-plane host discovered during the kubectl setup helpers) can reach the Kubernetes API and has `kubectl` available in `/var/lib/rancher/rke2/bin`.
 
 ## Usage
 
-Preview the inventory graph:
+### Maintenance workflow
 
-```bash
-ansible-inventory -i inventories/hosts.ini --graph
-```
-
-Run the maintenance workflow against a single cluster. The playbook targets the combined `kube_nodes` group and, thanks to the
-inventory ordering, finishes the control-plane hosts before moving on to workers:
+Run the maintenance workflow against a single cluster. The playbook targets the combined `kube_nodes` group and, thanks to the inventory ordering, finishes the control-plane hosts before moving on to workers:
 
 ```bash
 ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --limit kube_alpha
 ```
 
-> The play consumes the global `kube_nodes` aggregate (which includes `kube_control_plane` and `kube_workers`). Use `--limit <cluster>` to
-> narrow execution to a single cluster so the helper tasks can derive the correct delegate facts.
+> The play consumes the global `kube_nodes` aggregate (which includes `kube_control_plane` and `kube_workers`). Use `--limit <cluster>` to narrow execution to a single cluster so the helper tasks can derive the correct delegate facts.
 
 You can also target an individual host or a subset of node types:
 
@@ -87,15 +74,17 @@ ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --limit kube
 
 > **Note:** Each play runs with `serial: 1`, ensuring maintenance actions complete on one node before moving on to the next.
 
-Apply the GPU labels so that every node advertises whether a GPU is available. These labels are required when integrating with
-[HAMi](https://github.com/Project-HAMi/HAMi).
+### GPU labelling
+
+Apply the GPU labels so that every node advertises whether a GPU is available. These labels are required when integrating with [HAMi](https://github.com/Project-HAMi/HAMi).
 
 ```bash
 ansible-playbook -i inventories/hosts.ini playbooks/label-gpu-nodes.yml --limit kube_alpha
 ```
 
-Run the trace kit to capture network probes, Kubernetes object state, and component logs. Provide
-`trace_kit_targets` and optionally `trace_kit_flagged_namespaces` or restart lists (`trace_kit_restart_resources`) in an `extra-vars` file to customise the collection run:
+### Trace kit overview
+
+Use the trace kit to capture network probes, Kubernetes object state, and component logs for escalations:
 
 ```bash
 ansible-playbook -i inventories/hosts.ini playbooks/trace-kit.yml \
@@ -103,50 +92,11 @@ ansible-playbook -i inventories/hosts.ini playbooks/trace-kit.yml \
   -e @vars/trace-kit.yaml
 ```
 
-The play creates a timestamped archive under `artifacts/trace-kit/` containing per-node tests, cluster-wide
-events, pod logs (including CNI, kube-proxy, and CoreDNS), optional workload restarts, and workload manifests for reproducing
-failures in a test environment.
-
-When Longhorn is installed, trace kit gathers detailed diagnostics under `cluster/longhorn/`. It records high-level status
-tables for volumes, replicas, engines, nodes, share managers, and PersistentVolumes, captures the underlying custom resource
-manifests, and stores namespace events alongside `kubectl describe` output for every Longhorn pod. The role also tails pod
-logs grouped by component so you can quickly inspect manager, driver deployer, webhook, or instance manager activity. To help
-surface storage issues, the run highlights PersistentVolumes stuck in problematic phases (`Pending`, `Available`, `Released`,
-or `Failed`) or terminating and preserves both their manifests and `kubectl describe` output for root-cause analysis. Tune
-the behaviour with variables such as `trace_kit_capture_longhorn`, `trace_kit_longhorn_namespace`,
-`trace_kit_longhorn_status_commands`, `trace_kit_longhorn_resource_types`, `trace_kit_longhorn_trace_components`, and
-`trace_kit_longhorn_problematic_pv_phases`.
-
-#### Reproducing failed workloads in a test cluster
-
-1. Extract the generated tarball on your workstation:
-
-   ```bash
-   tar -xzf artifacts/trace-kit/trace-kit-<run_id>.tar.gz \
-     -C artifacts/trace-kit/
-   ```
-
-2. Review the extracted `cluster/reproduction/` directory. It contains:
-
-   - `pods/`: pod manifests captured for every workload stuck outside the `Running` phase.
-   - `owners/`: controller manifests (ReplicaSets, Deployments, StatefulSets, DaemonSets, Jobs, etc.) that manage the failed
-     pods. ReplicaSet owners automatically include their parent Deployment manifests so application rollouts can be replayed.
-
-3. Apply the manifests against a non-production cluster to recreate the workload state:
-
-   ```bash
-   kubectl apply -f cluster/reproduction/owners/
-   kubectl apply -f cluster/reproduction/pods/
-   ```
-
-   > **Tip:** Apply the controller manifests first (`owners/`) so the controllers manage subsequent pod lifecycles. Use a
-   > purpose-built namespace or cluster to avoid impacting production workloads.
+Read the [trace kit guide](docs/TRACE_KIT.md) for variable details, storage layout, and Longhorn-specific capture behaviour.
 
 ### Running ad-hoc commands
 
-Use Ansible ad-hoc commands for quick spot checks or remediation steps without running the full maintenance playbook. The
-examples below assume the provided inventory (`inventories/hosts.ini`) and demonstrate common tasks for an RKE2 cluster. Adjust
-the `--limit` values to match the hosts you want to target.
+Use Ansible ad-hoc commands for quick spot checks or remediation steps without running the full maintenance playbook. The examples below assume the provided inventory (`inventories/hosts.ini`) and demonstrate common tasks for an RKE2 cluster. Adjust the `--limit` values to match the hosts you want to target.
 
 Check the Kubernetes control-plane versions by running `kubectl` on every server node in the `kube_alpha` cluster:
 
@@ -193,8 +143,7 @@ ansible -i inventories/hosts.ini kube_alpha \
 
 ## Verification
 
-After making changes to the playbooks or inventory, run the following commands from an activated virtual environment to ensure
-the content remains valid:
+After making changes to the playbooks or inventory, run the following commands from an activated virtual environment to ensure the content remains valid:
 
 ```bash
 # Validate the inventory loads correctly

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,8 +1,10 @@
-# Onboarding Guide
+# Onboarding Playbook
 
-Follow this checklist to become productive quickly when working with the playbooks.
+Use this guide as a Day 1/Day 2 playbook. Day 1 gets your workstation ready to run the playbooks. Day 2 covers the routine actions you will perform while operating RKE2 clusters.
 
-## 1. Clone the repository
+## Day 1 – Environment setup
+
+### 1. Clone the repository
 
 ```bash
 git clone git@github.com:your-org/k8s-playbooks.git
@@ -11,7 +13,7 @@ cd k8s-playbooks
 
 > Replace the remote URL with the location of your fork if you are contributing changes.
 
-## 2. Create and activate the tooling virtual environment
+### 2. Bootstrap the tooling virtual environment
 
 Run the helper script and activate the environment in the same shell:
 
@@ -20,14 +22,16 @@ Run the helper script and activate the environment in the same shell:
 source .venv/bin/activate
 ```
 
-If you want to keep the virtual environment outside of the repository, set the `VENV_DIR` variable before invoking the script:
+If you prefer to store the virtual environment elsewhere, set `VENV_DIR` before invoking the script:
 
 ```bash
 VENV_DIR=$HOME/.virtualenvs/k8s-playbooks ./scripts/setup-ansible.sh
 source $HOME/.virtualenvs/k8s-playbooks/bin/activate
 ```
 
-## 3. Validate the installation
+Keep the environment active in every new shell so that the installed tooling remains available.
+
+### 3. Validate the installation
 
 After activation, confirm that both Ansible and the linter are available:
 
@@ -36,7 +40,7 @@ ansible --version
 ansible-lint --version
 ```
 
-## 4. Explore the inventory
+### 4. Explore the inventory
 
 Visualise the cluster layout to confirm your access to managed nodes:
 
@@ -44,24 +48,50 @@ Visualise the cluster layout to confirm your access to managed nodes:
 ansible-inventory -i inventories/hosts.ini --graph
 ```
 
-If you cannot reach the nodes yet, contact an administrator to obtain SSH access or to have the inventory updated with the
-appropriate hostnames.
+If you cannot reach the nodes yet, contact an administrator to obtain SSH access or to have the inventory updated with the appropriate hostnames.
 
-## 5. Dry-run the maintenance playbook
+## Day 2 – Routine operations
 
-Before making changes, perform a syntax check. This verifies that the playbook parses correctly without touching any hosts:
+### 1. Dry-run the maintenance playbook
+
+Run a syntax check to make sure the playbook parses correctly without touching any hosts:
 
 ```bash
 ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --syntax-check
 ```
 
-## 6. Apply changes responsibly
+Use this command after any local changes to catch errors before they reach production.
 
-When you are ready to run the maintenance workflow against a test environment, limit execution to the relevant cluster or host:
+### 2. Execute maintenance safely
+
+Limit execution to the relevant cluster or host and consider `--check` for a preview when tasks support it:
 
 ```bash
 ansible-playbook -i inventories/hosts.ini playbooks/maintenance.yml --limit kube_alpha
 ```
 
-Use the `--check` flag for a safe preview where possible, and always monitor the output for failed tasks. Reach out to the
-platform engineering team if you encounter unexpected behaviour.
+Monitor the output for failed tasks and coordinate with the platform engineering team if you encounter unexpected behaviour.
+
+### 3. Label GPU nodes when hardware changes
+
+Run the GPU labelling playbook whenever GPU-capable hosts are added or removed so scheduling metadata stays accurate:
+
+```bash
+ansible-playbook -i inventories/hosts.ini playbooks/label-gpu-nodes.yml --limit kube_alpha
+```
+
+### 4. Capture diagnostics with the trace kit
+
+Gather cluster-wide diagnostics during incidents or vendor escalations:
+
+```bash
+ansible-playbook -i inventories/hosts.ini playbooks/trace-kit.yml \
+  --limit kube_alpha \
+  -e @vars/trace-kit.yaml
+```
+
+Review [TRACE_KIT.md](TRACE_KIT.md) for variable descriptions, captured artefacts, and Longhorn-specific behaviour before running the play in production.
+
+### 5. Keep validation commands handy
+
+After any change to playbooks or inventory data, rerun the validation commands from Day 1 (ansible-inventory, ansible-lint, and syntax checks). They act as smoke tests that catch issues early.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -90,7 +90,9 @@ ansible-playbook -i inventories/hosts.ini playbooks/trace-kit.yml \
   -e @vars/trace-kit.yaml
 ```
 
-Review [TRACE_KIT.md](TRACE_KIT.md) for variable descriptions, captured artefacts, and Longhorn-specific behaviour before running the play in production.
+Copy [`vars/trace-kit.example.yml`](../vars/trace-kit.example.yml) to `vars/trace-kit.yaml` as a starting point and then review
+[TRACE_KIT.md](TRACE_KIT.md) for variable descriptions, captured artefacts, and Longhorn-specific behaviour before running the
+play in production.
 
 ### 5. Keep validation commands handy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 # Documentation Overview
 
-The documents in this directory expand on the information in the root `README.md`. They focus on making the project easier to
-understand, contribute to, and operate.
+The documents in this directory expand on the information in the root `README.md`. They focus on making the project easier to understand, contribute to, and operate.
 
 - [Onboarding guide](ONBOARDING.md) – step-by-step instructions for getting a local environment ready and verifying the tooling.
 - [Maintenance playbook reference](MAINTENANCE_PLAYBOOK.md) – explains the structure of the main playbook and how to extend it.
 - [Inventory conventions](INVENTORY.md) – documents how clusters and host variables are represented.
 - [Ansible development tips](ANSIBLE_TIPS.md) – practical advice for running, debugging, and iterating on playbooks.
+- [Trace kit guide](TRACE_KIT.md) – deep dive into diagnostics collection, captured artefacts, and reproduction workflows.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 The documents in this directory expand on the information in the root `README.md`. They focus on making the project easier to understand, contribute to, and operate.
 
-- [Onboarding guide](ONBOARDING.md) – step-by-step instructions for getting a local environment ready and verifying the tooling.
+- [Onboarding playbook](ONBOARDING.md) – Day 1 setup steps and Day 2 operational workflows for running the playbooks confidently.
 - [Maintenance playbook reference](MAINTENANCE_PLAYBOOK.md) – explains the structure of the main playbook and how to extend it.
 - [Inventory conventions](INVENTORY.md) – documents how clusters and host variables are represented.
 - [Ansible development tips](ANSIBLE_TIPS.md) – practical advice for running, debugging, and iterating on playbooks.

--- a/docs/TRACE_KIT.md
+++ b/docs/TRACE_KIT.md
@@ -1,0 +1,42 @@
+# Trace Kit Guide
+
+The trace kit playbook collects cluster diagnostics, node-level traces, and optional workload restarts to accelerate incident response and escalations.
+
+## Run the playbook
+
+Execute the playbook against the relevant cluster and provide customisation variables with an extra-vars file:
+
+```bash
+ansible-playbook -i inventories/hosts.ini playbooks/trace-kit.yml \
+  --limit kube_alpha \
+  -e @vars/trace-kit.yaml
+```
+
+Define the targets and optional namespaces or restart lists in the variable file:
+
+- `trace_kit_targets` – the hosts to probe.
+- `trace_kit_flagged_namespaces` – namespaces that need deeper inspection.
+- `trace_kit_restart_resources` – workloads that should be restarted during collection.
+
+## What gets captured
+
+Each run creates a timestamped archive under `artifacts/trace-kit/` containing per-node network tests, cluster-wide events, pod logs (including CNI, kube-proxy, and CoreDNS), optional workload restarts, and workload manifests for reproducing failures in a test environment.
+
+When Longhorn is installed, trace kit gathers detailed diagnostics under `cluster/longhorn/`. It records high-level status tables for volumes, replicas, engines, nodes, share managers, and PersistentVolumes, captures the underlying custom resource manifests, and stores namespace events alongside `kubectl describe` output for every Longhorn pod. The role also tails pod logs grouped by component so you can quickly inspect manager, driver deployer, webhook, or instance manager activity. To help surface storage issues, the run highlights PersistentVolumes stuck in problematic phases (`Pending`, `Available`, `Released`, or `Failed`) or terminating and preserves both their manifests and `kubectl describe` output for root-cause analysis. Tune the behaviour with variables such as `trace_kit_capture_longhorn`, `trace_kit_longhorn_namespace`, `trace_kit_longhorn_status_commands`, `trace_kit_longhorn_resource_types`, `trace_kit_longhorn_trace_components`, and `trace_kit_longhorn_problematic_pv_phases`.
+
+## Reproduce workloads in a test cluster
+
+1. Extract the generated tarball on your workstation:
+   ```bash
+   tar -xzf artifacts/trace-kit/trace-kit-<run_id>.tar.gz \
+     -C artifacts/trace-kit/
+   ```
+2. Review the extracted `cluster/reproduction/` directory. It contains:
+   - `pods/`: pod manifests captured for every workload stuck outside the `Running` phase.
+   - `owners/`: controller manifests (ReplicaSets, Deployments, StatefulSets, DaemonSets, Jobs, etc.) that manage the failed pods. ReplicaSet owners automatically include their parent Deployment manifests so application rollouts can be replayed.
+3. Apply the manifests against a non-production cluster to recreate the workload state:
+   ```bash
+   kubectl apply -f cluster/reproduction/owners/
+   kubectl apply -f cluster/reproduction/pods/
+   ```
+   > **Tip:** Apply the controller manifests first (`owners/`) so the controllers manage subsequent pod lifecycles. Use a purpose-built namespace or cluster to avoid impacting production workloads.

--- a/docs/TRACE_KIT.md
+++ b/docs/TRACE_KIT.md
@@ -12,11 +12,21 @@ ansible-playbook -i inventories/hosts.ini playbooks/trace-kit.yml \
   -e @vars/trace-kit.yaml
 ```
 
+Copy [`vars/trace-kit.example.yml`](../vars/trace-kit.example.yml) into place to start from the role defaults:
+
+```bash
+cp vars/trace-kit.example.yml vars/trace-kit.yaml
+```
+
 Define the targets and optional namespaces or restart lists in the variable file:
 
 - `trace_kit_targets` – the hosts to probe.
 - `trace_kit_flagged_namespaces` – namespaces that need deeper inspection.
 - `trace_kit_restart_resources` – workloads that should be restarted during collection.
+
+The example file also exposes switches for Longhorn captures, Cilium and Envoy Gateway diagnostics, pod log tailing, and the
+default workload selectors used for log collection. Leave sections unchanged to inherit the role defaults or override the
+values that matter for your cluster.
 
 ## What gets captured
 

--- a/vars/trace-kit.example.yml
+++ b/vars/trace-kit.example.yml
@@ -1,0 +1,113 @@
+# Example configuration for the trace kit playbook.
+#
+# Copy this file to `vars/trace-kit.yaml` and adjust values to match the
+# cluster you are targeting. Every variable is initialised with the role's
+# default so you can uncomment or edit only the sections you need.
+---
+# Base directories for storing diagnostics.
+trace_kit_remote_parent_dir: "/var/tmp/trace-kit"
+trace_kit_local_parent_dir: "{{ (playbook_dir | default('.')) ~ '/../artifacts/trace-kit' }}"
+
+# Network diagnostics targets. Provide a list of dictionaries with at least an
+# "address" key and optionally a "name" to describe the endpoint.
+trace_kit_targets: []
+trace_kit_ping_count: 5
+trace_kit_traceroute_options: "-n"
+trace_kit_curl_extra_args: "--fail --location --silent --show-error --output /dev/null"
+trace_kit_curl_format: "http_code=%{http_code} total_time=%{time_total} connect_time=%{time_connect}"
+
+# Longhorn diagnostics collection.
+trace_kit_capture_longhorn: true
+trace_kit_longhorn_namespace: longhorn-system
+trace_kit_longhorn_log_tail_lines: 500
+trace_kit_longhorn_status_commands:
+  - name: pods
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get pods -o wide"
+  - name: volumes
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get volumes.longhorn.io -o wide"
+  - name: nodes
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get nodes.longhorn.io -o wide"
+  - name: engines
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get engines.longhorn.io -o wide"
+  - name: replicas
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get replicas.longhorn.io -o wide"
+  - name: sharemanagers
+    command: "kubectl -n {{ trace_kit_longhorn_namespace }} get sharemanagers.longhorn.io -o wide"
+  - name: persistentvolumes
+    command: "kubectl get pv -o wide"
+trace_kit_longhorn_resource_types:
+  - volumes.longhorn.io
+  - engines.longhorn.io
+  - replicas.longhorn.io
+  - instance-managers.longhorn.io
+  - sharemanagers.longhorn.io
+  - backingimagemanagers.longhorn.io
+  - backingimagedatasources.longhorn.io
+  - nodes.longhorn.io
+  - settings.longhorn.io
+  - recurringjobs.longhorn.io
+trace_kit_longhorn_trace_components:
+  - name: manager
+    selector: "app=longhorn-manager"
+  - name: driver-deployer
+    selector: "app=longhorn-driver-deployer"
+  - name: ui
+    selector: "app=longhorn-ui"
+  - name: conversion-webhook
+    selector: "app=longhorn-conversion-webhook"
+  - name: admission-webhook
+    selector: "app=longhorn-admission-webhook"
+  - name: recovery-backend
+    selector: "app=longhorn-recovery-backend"
+  - name: instance-manager
+    selector: "longhorn.io/component=instance-manager"
+  - name: backing-image-manager
+    selector: "longhorn.io/component=backing-image-manager"
+  - name: share-manager
+    selector: "longhorn.io/component=share-manager"
+  - name: support-bundle-manager
+    selector: "longhorn.io/component=support-bundle-manager"
+trace_kit_longhorn_problematic_pv_phases:
+  - Pending
+  - Available
+  - Released
+  - Failed
+
+# Namespace specific verification.
+trace_kit_flagged_namespaces: []
+
+# Cilium diagnostics defaults.
+trace_kit_cilium_status_timeout_seconds: 300
+trace_kit_hubble_observe_last: 20
+
+# Envoy Gateway diagnostics defaults.
+trace_kit_envoy_gateway_namespace: envoy-gateway-system
+trace_kit_envoy_gateway_deployment: envoy-gateway
+trace_kit_envoy_gateway_log_tail_lines: 200
+
+# Optional restart behaviour. When enabled the resources listed in
+# trace_kit_restart_resources will be restarted with `kubectl
+# rollout` in a controlled way.
+trace_kit_enable_restarts: false
+trace_kit_restart_resources: []
+
+# Pod log capture defaults.
+trace_kit_pod_log_tail_lines: 500
+
+# Workload selectors used to capture key control plane diagnostics. These can
+# be extended per cluster.
+trace_kit_log_selectors:
+  - name: cni
+    namespace: kube-system
+    selector: "k8s-app in (calico-node,cilium,flannel,aws-node,weave-net,canal,azure-ip-masq-agent,azure-cni-networkmonitor)"
+  - name: kube-proxy
+    namespace: kube-system
+    selector: "k8s-app=kube-proxy"
+  - name: coredns
+    namespace: kube-system
+    selector: "k8s-app in (kube-dns,coredns)"
+
+# Host that should execute kubectl commands. When undefined the role attempts
+# to pick the first host in the kube_control_plane group or falls back to the
+# first host in the play.
+trace_kit_kubectl_delegate: null


### PR DESCRIPTION
## Summary
- split the root README quick-start flow into a concise Get Started section
- move the detailed trace kit walkthrough into a dedicated document under docs
- link the new trace kit guide from the documentation index for discoverability

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_6900754c52788323bdb9e803651dab63