### PR TITLE
Add RKE2 CIS 1.11 hardening playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository provides Ansible resources for operating Rancher Kubernetes Engi
 - A rolling maintenance playbook that drains, updates, reboots, and uncordons each host one at a time, using inventory ordering to service control-plane nodes before workers.
 - A GPU labelling playbook that detects NVIDIA hardware on each node and applies `gpu=on` or `gpu=off` Kubernetes labels so every node is consistently marked for GPU scheduling frameworks such as [HAMi](https://github.com/Project-HAMi/HAMi).
 - A trace kit playbook that gathers multi-node network traces, cluster diagnostics, and packages the findings for SRE or vendor escalation.
+- A CIS 1.11 hardening playbook that can audit or apply RKE2 security settings in line with the RKE2 CIS Self-Assessment Guide.
 
 See [`docs/README.md`](docs/README.md) for deep dives into playbook internals, inventory conventions, and onboarding material.
 
@@ -19,6 +20,7 @@ See [`docs/README.md`](docs/README.md) for deep dives into playbook internals, i
 ├── playbooks/
 │   ├── label-gpu-nodes.yml   # Apply the gpu=on label to hosts with NVIDIA hardware
 │   ├── maintenance.yml       # Entry point for the maintenance workflow
+│   ├── rke2-cis-hardening.yml # Audit and enforce RKE2 CIS 1.11 controls
 │   ├── trace-kit.yml         # Collect in-depth diagnostics for incident response
 │   └── tasks/
 │       └── common/           # Re-usable task snippets for maintenance actions
@@ -69,6 +71,22 @@ Apply the GPU labels so that every node advertises whether a GPU is available. T
 ```bash
 ansible-playbook -i inventories/hosts.ini playbooks/label-gpu-nodes.yml --limit kube_alpha
 ```
+
+### RKE2 CIS 1.11 hardening
+
+Audit an environment without changing it using Ansible check mode:
+
+```bash
+ansible-playbook -i inventories/hosts.ini playbooks/rke2-cis-hardening.yml --check
+```
+
+Apply the hardening settings to all nodes (control-plane and workers) in a single run:
+
+```bash
+ansible-playbook -i inventories/hosts.ini playbooks/rke2-cis-hardening.yml
+```
+
+See the full guide in [`docs/rke2-cis-1-11.md`](docs/rke2-cis-1-11.md) for variable-level customization and tagging.
 
 ### Trace kit overview
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = roles

--- a/docs/rke2-cis-1-11.md
+++ b/docs/rke2-cis-1-11.md
@@ -1,0 +1,42 @@
+# RKE2 CIS 1.11 Hardening Playbook
+
+This playbook applies the controls from the [RKE2 CIS 1.11 Self-Assessment Guide](https://docs.rke2.io/security/cis_self_assessment111) and can also be run in check mode to audit an existing cluster. The role focuses on reproducible system configuration, idempotent file permissions, and lightweight reporting of deviations.
+
+## Inventory targeting
+
+The playbook assumes the static inventory found at `inventories/hosts.ini`. Target all nodes with `kube_nodes` or restrict to control-plane or worker nodes with `kube_control_plane` and `kube_workers`.
+
+## Running in audit (noop) mode
+
+Use Ansible check mode to view the current cluster state without changing it:
+
+```bash
+ansible-playbook -i inventories/hosts.ini playbooks/rke2-cis-hardening.yml --check
+```
+
+The audit summary reports any sysctl or file permission mismatches against the CIS profile.
+
+## Applying the CIS profile
+
+Run the playbook normally to apply the hardening settings:
+
+```bash
+ansible-playbook -i inventories/hosts.ini playbooks/rke2-cis-hardening.yml
+```
+
+Use `-e rke2_cis_1_11_apply=false` to skip remediation tasks while still generating the audit report.
+
+## Customizing controls
+
+All knobs live in `roles/rke2_cis_1_11/defaults/main.yml`:
+
+- `rke2_cis_1_11_sysctl_overrides` manages kernel and networking tunables and writes them to `/etc/sysctl.d/60-rke2-cis.conf`.
+- `rke2_cis_1_11_config` renders a drop-in at `/etc/rancher/rke2/config.yaml.d/90-cis-profile.yaml` with hardened API server, controller manager, scheduler, kubelet, and kube-proxy arguments.
+- `rke2_cis_1_11_file_permissions` defines permission expectations for sensitive RKE2 assets.
+- `rke2_cis_1_11_audit_policy_path` controls where the managed audit policy is written; update the template at `roles/rke2_cis_1_11/templates/audit-policy.yaml.j2` if you need finer-grained logging.
+
+## Tags
+
+- `cis` covers the full role
+- `harden` limits execution to remediation tasks
+- `audit` limits execution to the reporting steps

--- a/playbooks/rke2-cis-hardening.yml
+++ b/playbooks/rke2-cis-hardening.yml
@@ -1,0 +1,8 @@
+---
+- name: Apply RKE2 CIS 1.11 profile
+  hosts: kube_nodes
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: rke2_cis_1_11

--- a/roles/rke2_cis_1_11/defaults/main.yml
+++ b/roles/rke2_cis_1_11/defaults/main.yml
@@ -1,0 +1,108 @@
+---
+# Default controls for the RKE2 CIS 1.11 profile.
+rke2_cis_1_11_profile: "cis-1.11"
+
+rke2_cis_1_11_apply: true
+
+rke2_cis_1_11_config_dir: /etc/rancher/rke2/config.yaml.d
+rke2_cis_1_11_sysctl_conf: /etc/sysctl.d/60-rke2-cis.conf
+rke2_cis_1_11_audit_policy_path: /etc/rancher/rke2/audit-policy.yaml
+
+# Map of sysctl values collected from the CIS 1.11 benchmark guidance.
+rke2_cis_1_11_sysctl_overrides:
+  kernel.panic: 10
+  kernel.panic_on_oops: 1
+  kernel.keys.root_maxbytes: 25000000
+  kernel.keys.root_maxkeys: 1000000
+  net.bridge.bridge-nf-call-iptables: 1
+  net.bridge.bridge-nf-call-ip6tables: 1
+  net.ipv4.ip_forward: 1
+  net.ipv4.conf.all.accept_redirects: 0
+  net.ipv4.conf.all.accept_source_route: 0
+  net.ipv4.conf.all.log_martians: 1
+  net.ipv4.conf.all.rp_filter: 1
+  net.ipv4.conf.default.accept_redirects: 0
+  net.ipv4.conf.default.accept_source_route: 0
+  net.ipv4.conf.default.log_martians: 1
+  net.ipv4.conf.default.rp_filter: 1
+  net.ipv4.tcp_syncookies: 1
+  net.ipv6.conf.all.accept_ra: 0
+  net.ipv6.conf.default.accept_ra: 0
+  vm.overcommit_memory: 1
+  vm.panic_on_oom: 0
+
+# RKE2 configuration tuned for the CIS 1.11 profile.
+rke2_cis_1_11_config:
+  profile: "{{ rke2_cis_1_11_profile }}"
+  protect-kernel-defaults: true
+  write-kubeconfig-mode: "0640"
+  selinux: true
+  audit-policy-file: "{{ rke2_cis_1_11_audit_policy_path }}"
+  kube-apiserver-arg:
+    - audit-log-path=/var/lib/rancher/rke2/server/logs/audit.log
+    - audit-log-maxage=30
+    - audit-log-maxbackup=10
+    - audit-log-maxsize=100
+    - authorization-mode=Node,RBAC
+    - enable-admission-plugins=NamespaceLifecycle,ServiceAccount,NodeRestriction
+    - anonymous-auth=false
+    - profiling=false
+    - service-account-lookup=true
+  kube-controller-manager-arg:
+    - address=127.0.0.1
+    - bind-address=127.0.0.1
+    - terminated-pod-gc-threshold=1000
+    - use-service-account-credentials=true
+  kube-scheduler-arg:
+    - address=127.0.0.1
+    - bind-address=127.0.0.1
+    - profiling=false
+  kubelet-arg:
+    - authorization-mode=Webhook
+    - authentication-token-webhook=true
+    - anonymous-auth=false
+    - streaming-connection-idle-timeout=5m
+    - protect-kernel-defaults=true
+    - make-iptables-util-chains=true
+    - read-only-port=0
+    - rotate-certificates=true
+  kube-proxy-arg:
+    - metrics-bind-address=127.0.0.1:10249
+
+# File permission controls grouped for reporting and remediation.
+rke2_cis_1_11_file_permissions:
+  - path: /etc/rancher/rke2
+    state: directory
+    mode: "0750"
+    owner: root
+    group: root
+  - path: /etc/rancher/rke2/config.yaml
+    state: file
+    mode: "0600"
+    owner: root
+    group: root
+  - path: /etc/rancher/rke2/config.yaml.d
+    state: directory
+    mode: "0750"
+    owner: root
+    group: root
+  - path: /var/lib/rancher/rke2/server/node-token
+    state: file
+    mode: "0600"
+    owner: root
+    group: root
+  - path: /var/lib/rancher/rke2/server/token
+    state: file
+    mode: "0600"
+    owner: root
+    group: root
+  - path: /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+    state: file
+    mode: "0640"
+    owner: root
+    group: root
+  - path: /var/lib/rancher/rke2/agent/kubelet.conf
+    state: file
+    mode: "0640"
+    owner: root
+    group: root

--- a/roles/rke2_cis_1_11/handlers/main.yml
+++ b/roles/rke2_cis_1_11/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload sysctl
+  ansible.builtin.command: sysctl --system
+  changed_when: true

--- a/roles/rke2_cis_1_11/tasks/main.yml
+++ b/roles/rke2_cis_1_11/tasks/main.yml
@@ -1,0 +1,135 @@
+---
+- name: Verify RKE2 install presence for CIS hardening
+  ansible.builtin.stat:
+    path: /etc/rancher/rke2
+  register: rke2_cis_1_11_rke2_path
+  failed_when: not rke2_cis_1_11_rke2_path.stat.exists
+  tags:
+    - cis
+    - audit
+
+- name: Build hardening directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: "0750"
+  loop:
+    - "/etc/rancher/rke2"
+    - "{{ rke2_cis_1_11_config_dir }}"
+  when: rke2_cis_1_11_apply | bool
+  tags:
+    - cis
+    - harden
+
+- name: Prepare sysctl drop-in for CIS controls
+  ansible.builtin.template:
+    src: sysctl.conf.j2
+    dest: "{{ rke2_cis_1_11_sysctl_conf }}"
+    owner: root
+    group: root
+    mode: "0644"
+  when: rke2_cis_1_11_apply | bool
+  notify:
+    - Reload sysctl
+  tags:
+    - cis
+    - harden
+
+- name: Render audit policy aligned with CIS guidance
+  ansible.builtin.template:
+    src: audit-policy.yaml.j2
+    dest: "{{ rke2_cis_1_11_audit_policy_path }}"
+    owner: root
+    group: root
+    mode: "0640"
+  when: rke2_cis_1_11_apply | bool
+  tags:
+    - cis
+    - harden
+
+- name: Render RKE2 CIS profile configuration
+  ansible.builtin.template:
+    src: cis-config.yaml.j2
+    dest: "{{ rke2_cis_1_11_config_dir }}/90-cis-profile.yaml"
+    owner: root
+    group: root
+    mode: "0640"
+  when: rke2_cis_1_11_apply | bool
+  tags:
+    - cis
+    - harden
+
+- name: Ensure permissions align with CIS expectations
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: "{{ item.state }}"
+    mode: "{{ item.mode }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+  loop: "{{ rke2_cis_1_11_file_permissions }}"
+  when: rke2_cis_1_11_apply | bool
+  tags:
+    - cis
+    - harden
+
+- name: Capture current sysctl values for reporting
+  ansible.builtin.command: sysctl -n {{ item.key }}
+  loop: "{{ rke2_cis_1_11_sysctl_overrides | dict2items }}"
+  register: rke2_cis_1_11_sysctl_checks
+  changed_when: false
+  failed_when: false
+  tags:
+    - cis
+    - audit
+
+- name: Summarize sysctl drift from CIS expectations
+  ansible.builtin.set_fact:
+    rke2_cis_1_11_sysctl_report: >-
+      {{ (rke2_cis_1_11_sysctl_report | default([]))
+         + [{'name': item.item.key,
+             'expected': (item.item.value | string),
+             'observed': item.stdout}] }}
+  loop: "{{ rke2_cis_1_11_sysctl_checks.results }}"
+  when: item.stdout is defined and item.stdout != (item.item.value | string)
+  tags:
+    - cis
+    - audit
+
+- name: Stat CIS-controlled file permissions
+  ansible.builtin.stat:
+    path: "{{ item.path }}"
+    follow: true
+  register: rke2_cis_1_11_file_stats
+  loop: "{{ rke2_cis_1_11_file_permissions }}"
+  changed_when: false
+  failed_when: false
+  tags:
+    - cis
+    - audit
+
+- name: Summarize file permission drift
+  ansible.builtin.set_fact:
+    rke2_cis_1_11_file_report: >-
+      {{ (rke2_cis_1_11_file_report | default([]))
+         + [{'path': item.item.path,
+             'expected_mode': item.item.mode,
+             'observed_mode': item.stat.mode if item.stat is defined else 'missing',
+             'expected_owner': item.item.owner,
+             'observed_owner': item.stat.pw_name if item.stat is defined else 'missing',
+             'expected_group': item.item.group,
+             'observed_group': item.stat.gr_name if item.stat is defined else 'missing'}] }}
+  loop: "{{ rke2_cis_1_11_file_stats.results }}"
+  when: item.stat is not defined or item.stat.mode != item.item.mode or item.stat.pw_name != item.item.owner or item.stat.gr_name != item.item.group
+  tags:
+    - cis
+    - audit
+
+- name: Report CIS controls requiring attention
+  ansible.builtin.debug:
+    msg: |
+      RKE2 CIS 1.11 audit completed.
+      Sysctl mismatches ({{ (rke2_cis_1_11_sysctl_report | default([])) | length }}): {{ rke2_cis_1_11_sysctl_report | default([]) }}
+      File permission mismatches ({{ (rke2_cis_1_11_file_report | default([])) | length }}): {{ rke2_cis_1_11_file_report | default([]) }}
+  tags:
+    - cis
+    - audit

--- a/roles/rke2_cis_1_11/templates/audit-policy.yaml.j2
+++ b/roles/rke2_cis_1_11/templates/audit-policy.yaml.j2
@@ -1,0 +1,21 @@
+# Managed by Ansible: minimal audit policy compatible with CIS 1.11
+apiVersion: audit.k8s.io/v1
+kind: Policy
+metadata:
+  name: rke2-cis-1-11
+rules:
+  - level: Metadata
+    resources:
+      - group: ""
+        resources: [pods, pods/log, secrets, configmaps, services]
+      - group: "rbac.authorization.k8s.io"
+        resources: [roles, rolebindings, clusterroles, clusterrolebindings]
+  - level: RequestResponse
+    verbs: [create, update, patch, delete]
+    resources:
+      - group: ""
+        resources: [pods, pods/attach, pods/exec, pods/portforward, secrets]
+  - level: None
+    resources:
+      - group: ""
+        resources: [events]

--- a/roles/rke2_cis_1_11/templates/cis-config.yaml.j2
+++ b/roles/rke2_cis_1_11/templates/cis-config.yaml.j2
@@ -1,0 +1,2 @@
+# Managed by Ansible: RKE2 CIS {{ rke2_cis_1_11_profile }} profile settings
+{{ rke2_cis_1_11_config | to_nice_yaml(indent=2) }}

--- a/roles/rke2_cis_1_11/templates/sysctl.conf.j2
+++ b/roles/rke2_cis_1_11/templates/sysctl.conf.j2
@@ -1,0 +1,3 @@
+# Managed by Ansible: CIS Kubernetes 1.11 recommendations for RKE2
+{% for key, value in rke2_cis_1_11_sysctl_overrides.items() %}{{ key }} = {{ value }}
+{% endfor %}


### PR DESCRIPTION
## Summary
- add a dedicated RKE2 CIS 1.11 hardening playbook and role to audit or enforce benchmark controls
- template sysctl, audit policy, and profile drop-ins with opinionated defaults for RKE2 services and file permissions
- document usage and set repository roles path for predictable role resolution

## Testing
- ansible-lint playbooks/rke2-cis-hardening.yml
- ansible-playbook -i inventories/hosts.ini playbooks/rke2-cis-hardening.yml --syntax-check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937c8ffa7a48323bff85912437d58f9)